### PR TITLE
ci: pare down unit tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.11"]
       fail-fast: false
     steps:
       - name: Remove PR label


### PR DESCRIPTION
Have unit tests run on min and max supported versions only.