### PR TITLE
chore: prefer `publicKey` over `pemCSR` in API

### DIFF
--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -21,7 +21,6 @@ import aiohttp
 from cryptography.hazmat.primitives import serialization
 
 from google.auth.transport.requests import Request
-from google.cloud.alloydb.connector.utils import _create_certificate_request
 from google.cloud.alloydb.connector.version import __version__ as version
 
 if TYPE_CHECKING:

--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -150,12 +150,15 @@ class AlloyDBClient:
 
         url = f"{self._alloydb_api_endpoint}/{API_VERSION}/projects/{project}/locations/{region}/clusters/{cluster}:generateClientCertificate"
 
-        # create the certificate signing request
-        csr = _create_certificate_request(key)
-        csr_str = csr.public_bytes(encoding=serialization.Encoding.PEM).decode("utf-8")
+        # get client public key
+        pub_key = key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        pub_key_str = pub_key.decode("UTF-8")
 
         data = {
-            "pemCsr": csr_str,
+            "publicKey": pub_key_str,
             "certDuration": "3600s",
         }
 

--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, Tuple, TYPE_CHECKING
 
 import aiohttp
 from cryptography.hazmat.primitives import serialization
@@ -117,7 +117,7 @@ class AlloyDBClient:
         region: str,
         cluster: str,
         key: rsa.RSAPrivateKey,
-    ) -> List[str]:
+    ) -> Tuple[str, List[str]]:
         """
         Fetch a client certificate for the given AlloyDB cluster.
 
@@ -134,7 +134,7 @@ class AlloyDBClient:
                 to generate client certificate.
 
         Returns:
-            Tuple[str, list[str]]: Tuple containing the client certificate
+            Tuple[str, list[str]]: Tuple containing the CA certificate
                 and certificate chain for the AlloyDB instance.
         """
         logger.debug(f"['{project}/{region}/{cluster}']: Requesting client certificate")
@@ -166,7 +166,7 @@ class AlloyDBClient:
         )
         resp_dict = await resp.json()
 
-        return resp_dict["pemCertificateChain"]
+        return (resp_dict["caCert"], resp_dict["pemCertificateChain"])
 
     async def close(self) -> None:
         """Close AlloyDBClient gracefully."""

--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Optional, Tuple, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 
 import aiohttp
 from cryptography.hazmat.primitives import serialization
@@ -117,7 +117,7 @@ class AlloyDBClient:
         region: str,
         cluster: str,
         key: rsa.RSAPrivateKey,
-    ) -> Tuple[str, List[str]]:
+    ) -> List[str]:
         """
         Fetch a client certificate for the given AlloyDB cluster.
 
@@ -166,7 +166,7 @@ class AlloyDBClient:
         )
         resp_dict = await resp.json()
 
-        return (resp_dict["pemCertificate"], resp_dict["pemCertificateChain"])
+        return resp_dict["pemCertificateChain"]
 
     async def close(self) -> None:
         """Close AlloyDBClient gracefully."""

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -20,13 +20,12 @@ from threading import Thread
 from types import TracebackType
 from typing import Any, Dict, Optional, Type, TYPE_CHECKING
 
-from cryptography.hazmat.primitives.asymmetric import rsa
-
 from google.auth import default
 from google.auth.credentials import with_scopes_if_required
 from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector.instance import Instance
 import google.cloud.alloydb.connector.pg8000 as pg8000
+from google.cloud.alloydb.connector.utils import generate_keys
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials
@@ -68,7 +67,7 @@ class Connector:
         # otherwise use application default credentials
         else:
             self._credentials, _ = default(scopes=scopes)
-        self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self._keys = generate_keys()
         self._client: Optional[AlloyDBClient] = None
 
     def connect(self, instance_uri: str, driver: str, **kwargs: Any) -> Any:
@@ -127,7 +126,7 @@ class Connector:
             instance = Instance(
                 instance_uri,
                 self._client,
-                self._key,
+                self._keys,
             )
             self._instances[instance_uri] = instance
 

--- a/google/cloud/alloydb/connector/refresh.py
+++ b/google/cloud/alloydb/connector/refresh.py
@@ -19,7 +19,7 @@ from datetime import datetime
 import logging
 import ssl
 from tempfile import TemporaryDirectory
-from typing import List, TYPE_CHECKING
+from typing import List, Tuple, TYPE_CHECKING
 
 from cryptography import x509
 
@@ -75,10 +75,9 @@ class RefreshResult:
     """
 
     def __init__(
-        self, instance_ip: str, key: rsa.RSAPrivateKey, cert_chain: List[str]
+        self, instance_ip: str, key: rsa.RSAPrivateKey, certs: Tuple[str, List[str]]
     ) -> None:
         self.instance_ip = instance_ip
-
         # create TLS context
         self.context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         # update ssl.PROTOCOL_TLS_CLIENT default
@@ -87,7 +86,8 @@ class RefreshResult:
         self.context.minimum_version = ssl.TLSVersion.TLSv1_3
         # add request_ssl attribute to ssl.SSLContext, required for pg8000 driver
         self.context.request_ssl = False  # type: ignore
-
+        # unpack certs
+        ca_cert, cert_chain = certs
         # get expiration from client certificate
         cert_obj = x509.load_pem_x509_certificate(cert_chain[0].encode("UTF-8"))
         self.expiration = cert_obj.not_valid_after
@@ -97,7 +97,7 @@ class RefreshResult:
         # need to be written to files in order to be loaded by the SSLContext
         with TemporaryDirectory() as tmpdir:
             ca_filename, cert_chain_filename, key_filename = _write_to_file(
-                tmpdir, cert_chain, key
+                tmpdir, ca_cert, cert_chain, key
             )
             self.context.load_cert_chain(cert_chain_filename, keyfile=key_filename)
             self.context.load_verify_locations(cafile=ca_filename)

--- a/google/cloud/alloydb/connector/utils.py
+++ b/google/cloud/alloydb/connector/utils.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 def _write_to_file(
-    dir_path: str, cert_chain: List[str], key: rsa.RSAPrivateKey
+    dir_path: str, ca_cert: str, cert_chain: List[str], key: rsa.RSAPrivateKey
 ) -> Tuple[str, str, str]:
     """
     Helper function to write the server_ca, client certificate and
@@ -40,7 +40,7 @@ def _write_to_file(
     )
 
     with open(ca_filename, "w+") as ca_out:
-        ca_out.write("".join(cert_chain))
+        ca_out.write(ca_cert)
     with open(cert_chain_filename, "w+") as chain_out:
         chain_out.write("".join(cert_chain))
     with open(key_filename, "wb") as priv_out:
@@ -49,7 +49,7 @@ def _write_to_file(
     return (ca_filename, cert_chain_filename, key_filename)
 
 
-async def generate_keys() -> Tuple[rsa.RSAPrivateKey, str]:
+def generate_keys() -> Tuple[rsa.RSAPrivateKey, str]:
     priv_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     pub_key = (
         priv_key.public_key()

--- a/google/cloud/alloydb/connector/utils.py
+++ b/google/cloud/alloydb/connector/utils.py
@@ -16,16 +16,14 @@ from __future__ import annotations
 
 from typing import List, Tuple, TYPE_CHECKING
 
-from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import serialization
 
 if TYPE_CHECKING:
     from cryptography.hazmat.primitives.asymmetric import rsa
 
 
 def _write_to_file(
-    dir_path: str, cert_chain: List[str], client_cert: str, key: rsa.RSAPrivateKey
+    dir_path: str, cert_chain: List[str], key: rsa.RSAPrivateKey
 ) -> Tuple[str, str, str]:
     """
     Helper function to write the server_ca, client certificate and
@@ -41,13 +39,10 @@ def _write_to_file(
         encryption_algorithm=serialization.NoEncryption(),
     )
 
-    # add client cert to beginning of cert chain
-    full_chain = [client_cert] + cert_chain
-
     with open(ca_filename, "w+") as ca_out:
         ca_out.write("".join(cert_chain))
     with open(cert_chain_filename, "w+") as chain_out:
-        chain_out.write("".join(full_chain))
+        chain_out.write("".join(cert_chain))
     with open(key_filename, "wb") as priv_out:
         priv_out.write(key_bytes)
 

--- a/google/cloud/alloydb/connector/utils.py
+++ b/google/cloud/alloydb/connector/utils.py
@@ -14,12 +14,10 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple, TYPE_CHECKING
+from typing import List, Tuple
 
 from cryptography.hazmat.primitives import serialization
-
-if TYPE_CHECKING:
-    from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 
 def _write_to_file(

--- a/google/cloud/alloydb/connector/utils.py
+++ b/google/cloud/alloydb/connector/utils.py
@@ -54,23 +54,14 @@ def _write_to_file(
     return (ca_filename, cert_chain_filename, key_filename)
 
 
-def _create_certificate_request(
-    private_key: rsa.RSAPrivateKey,
-) -> x509.CertificateSigningRequest:
-    csr = (
-        x509.CertificateSigningRequestBuilder()
-        .subject_name(
-            x509.Name(
-                [
-                    x509.NameAttribute(NameOID.COMMON_NAME, "alloydb-connector"),
-                    x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-                    x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "CA"),
-                    x509.NameAttribute(NameOID.LOCALITY_NAME, "Sunnyvale"),
-                    x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Google LLC"),
-                    x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, "Cloud"),
-                ]
-            )
+async def generate_keys() -> Tuple[rsa.RSAPrivateKey, str]:
+    priv_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_key = (
+        priv_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
         )
-        .sign(private_key, hashes.SHA256())
+        .decode("UTF-8")
     )
-    return csr
+    return (priv_key, pub_key)


### PR DESCRIPTION
Prefer `publicKey` over `pemCSR` in API request body.

Will follow up after this PR with #14 to make key generation async and non-blocking

Closes #110 