### PR TITLE
chore: add py.typed marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,4 +76,5 @@ setup(
     python_requires=">=3.8",
     include_package_data=True,
     zip_safe=False,
+    package_data={"google.cloud.alloydb.connector": ["py.typed"]},
 )


### PR DESCRIPTION
The library is fully typed, so add a marker to allow linters like `mypy` to pick this up as specified in PEP561.