### PR TITLE
chore: update lint job to use `isort`

### DIFF
--- a/google/cloud/alloydb/connector/__init__.py
+++ b/google/cloud/alloydb/connector/__init__.py
@@ -14,5 +14,4 @@
 from google.cloud.alloydb.connector.connector import Connector
 from google.cloud.alloydb.connector.version import __version__
 
-
 __all__ = ["__version__", "Connector"]

--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -18,8 +18,8 @@ import logging
 from typing import List, Optional, Tuple, TYPE_CHECKING
 
 import aiohttp
-
 from google.auth.transport.requests import Request
+
 from google.cloud.alloydb.connector.version import __version__ as version
 
 if TYPE_CHECKING:

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, Optional, Type, TYPE_CHECKING
 
 from google.auth import default
 from google.auth.credentials import with_scopes_if_required
+
 from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector.instance import Instance
 import google.cloud.alloydb.connector.pg8000 as pg8000

--- a/google/cloud/alloydb/connector/instance.py
+++ b/google/cloud/alloydb/connector/instance.py
@@ -21,15 +21,15 @@ from typing import Tuple, TYPE_CHECKING
 
 from google.cloud.alloydb.connector.exceptions import RefreshError
 from google.cloud.alloydb.connector.rate_limiter import AsyncRateLimiter
-from google.cloud.alloydb.connector.refresh import (
-    _is_valid,
-    _seconds_until_refresh,
-    RefreshResult,
-)
+from google.cloud.alloydb.connector.refresh import _is_valid
+from google.cloud.alloydb.connector.refresh import _seconds_until_refresh
+from google.cloud.alloydb.connector.refresh import RefreshResult
 
 if TYPE_CHECKING:
     import ssl
+
     from cryptography.hazmat.primitives.asymmetric import rsa
+
     from google.cloud.alloydb.connector.client import AlloyDBClient
 
 logger = logging.getLogger(name=__name__)

--- a/google/cloud/alloydb/connector/refresh.py
+++ b/google/cloud/alloydb/connector/refresh.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime
+from datetime import timezone
 import logging
 import ssl
 from tempfile import TemporaryDirectory

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 
 import nox
 
-
-BLACK_VERSION = "black==22.3.0"
+BLACK_VERSION = "black==23.12.1"
+ISORT_VERSION = "isort==5.13.2"
 LINT_PATHS = ["google", "tests", "noxfile.py", "setup.py"]
 
 SYSTEM_TEST_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
@@ -36,22 +37,29 @@ def lint(session):
     session.install("-r", "requirements.txt")
     session.install(
         "flake8",
-        "flake8-import-order",
         "flake8-annotations",
         "mypy",
         BLACK_VERSION,
+        ISORT_VERSION,
         "types-setuptools",
         "twine",
     )
     session.run(
+        "isort",
+        "--fss",
+        "--check-only",
+        "--diff",
+        "--profile=google",
+        *LINT_PATHS,
+    )
+    session.run(
         "black",
         "--check",
+        "--diff",
         *LINT_PATHS,
     )
     session.run(
         "flake8",
-        "--import-order-style=google",
-        "--application-import-names=google,tests",
         "google",
         "tests",
     )
@@ -74,6 +82,27 @@ def blacken(session):
     Format code to uniform standard.
     """
     session.install(BLACK_VERSION)
+    session.run(
+        "black",
+        *LINT_PATHS,
+    )
+
+
+@nox.session()
+def format(session):
+    """
+    Run isort to sort imports. Then run black
+    to format code to uniform standard.
+    """
+    session.install(BLACK_VERSION, ISORT_VERSION)
+    # Use the --fss option to sort imports using strict alphabetical order.
+    # See https://pycqa.github.io/isort/docs/configuration/options.html#force-sort-within-sectionss
+    session.run(
+        "isort",
+        "--fss",
+        "--profile=google",
+        *LINT_PATHS,
+    )
     session.run(
         "black",
         *LINT_PATHS,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 import io
 import os
 
-from setuptools import find_namespace_packages, setup
+import setuptools
 
 name = "google-cloud-alloydb-connector"
 description = "A Python client library for connecting securely to your Google Cloud AlloyDB instances."
@@ -43,11 +43,13 @@ version = version["__version__"]
 # Only include packages under the 'google' namespace. Do not include tests,
 # samples, etc.
 packages = [
-    package for package in find_namespace_packages() if package.startswith("google")
+    package
+    for package in setuptools.find_namespace_packages()
+    if package.startswith("google")
 ]
 
 
-setup(
+setuptools.setup(
     name=name,
     version=version,
     description=description,

--- a/tests/system/test_native_asyncpg_direct_connection.py
+++ b/tests/system/test_native_asyncpg_direct_connection.py
@@ -18,7 +18,6 @@ import os
 
 # [START alloydb_native_asyncpg_connect_iam_authn_direct]
 import asyncpg
-
 import google.auth
 from google.auth.transport.requests import Request
 

--- a/tests/system/test_psycopg2_direct_connection.py
+++ b/tests/system/test_psycopg2_direct_connection.py
@@ -17,12 +17,11 @@ from datetime import datetime
 import os
 
 # [START alloydb_psycopg2_connect_iam_authn_direct]
-import sqlalchemy
-from sqlalchemy import event
-
 import google.auth
 from google.auth.credentials import Credentials
 from google.auth.transport.requests import Request
+import sqlalchemy
+from sqlalchemy import event
 
 # [END alloydb_psycopg2_connect_iam_authn_direct]
 

--- a/tests/system/test_sqlalchemy_asyncpg_direct_connection.py
+++ b/tests/system/test_sqlalchemy_asyncpg_direct_connection.py
@@ -17,13 +17,12 @@ from datetime import datetime
 import os
 
 # [START alloydb_sqlalchemy_asyncpg_connect_iam_authn_direct]
-import sqlalchemy
-from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy import event
-
 import google.auth
 from google.auth.credentials import Credentials
 from google.auth.transport.requests import Request
+import sqlalchemy
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import create_async_engine
 
 # [END alloydb_sqlalchemy_asyncpg_connect_iam_authn_direct]
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mocks import (
-    FakeCredentials,
-    FakeInstance,
-)
+from mocks import FakeCredentials
+from mocks import FakeInstance
 import pytest
 
 

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 from typing import Any, Callable, List, Optional, Tuple
 
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -16,7 +16,8 @@ import asyncio
 from threading import Thread
 
 from mock import patch
-from mocks import FakeAlloyDBClient, FakeCredentials
+from mocks import FakeAlloyDBClient
+from mocks import FakeCredentials
 import pytest
 
 from google.cloud.alloydb.connector import Connector

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from typing import Tuple
 
 import aiohttp
@@ -21,8 +22,10 @@ from mocks import FakeAlloyDBClient
 import pytest
 
 from google.cloud.alloydb.connector.exceptions import RefreshError
-from google.cloud.alloydb.connector.instance import _parse_instance_uri, Instance
-from google.cloud.alloydb.connector.refresh import _is_valid, RefreshResult
+from google.cloud.alloydb.connector.instance import _parse_instance_uri
+from google.cloud.alloydb.connector.instance import Instance
+from google.cloud.alloydb.connector.refresh import _is_valid
+from google.cloud.alloydb.connector.refresh import RefreshResult
 from google.cloud.alloydb.connector.utils import generate_keys
 
 

--- a/tests/unit/test_refresh.py
+++ b/tests/unit/test_refresh.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 import ssl
 
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from mocks import FakeInstance
 
-from google.cloud.alloydb.connector.refresh import (
-    _seconds_until_refresh,
-    RefreshResult,
-)
+from google.cloud.alloydb.connector.refresh import _seconds_until_refresh
+from google.cloud.alloydb.connector.refresh import RefreshResult
 
 
 def test_seconds_until_refresh_over_1_hour() -> None:


### PR DESCRIPTION
Switching to `isort` over `flake8-import-order` as it is better to use a sorter then using the sorting check of a linter.