### PR TITLE
chore: remove need for pytest in sample

### DIFF
--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -17,7 +17,6 @@ from typing import Tuple
 
 # [START alloydb_sqlalchemy_connect_async_connector]
 import asyncpg
-import pytest
 import sqlalchemy
 import sqlalchemy.ext.asyncio
 
@@ -84,7 +83,6 @@ async def create_sqlalchemy_engine(
 # [END alloydb_sqlalchemy_connect_async_connector]
 
 
-@pytest.mark.asyncio
 async def test_connection_with_asyncpg() -> None:
     """Basic test to get time from database."""
     inst_uri = os.environ["ALLOYDB_INSTANCE_URI"]


### PR DESCRIPTION
Currently `import pytest` will show inside of code sample in docs since it is in the region tag. I have tests set to auto-use async if they are an async function so the marking of the test as async is redundant and can be removed.