### PR TITLE
chore: bump lint to Python 3.12

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       
       - name: Install nox
         run: pip install nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ def lint(session):
         "mypy",
         BLACK_VERSION,
         ISORT_VERSION,
-        "types-setuptools",
+        "build",
         "twine",
     )
     session.run(
@@ -71,8 +71,9 @@ def lint(session):
         "--non-interactive",
         "--show-traceback",
     )
-    session.run("python", "setup.py", "sdist")
-    session.run("twine", "check", "dist/*")
+    # verify that setup.py is valid
+    session.run("python", "-m", "build", "--sdist")
+    session.run("twine", "check", "--strict", "dist/*")
 
 
 @nox.session


### PR DESCRIPTION
Update lint build to run using Python 3.12, updating `python setup.py sdist` to use build instead as the command is deprecated as of Python 3.12