### PR TITLE
chore: use new `not_valid_after_utc` cert field

### DIFF
--- a/google/cloud/alloydb/connector/refresh.py
+++ b/google/cloud/alloydb/connector/refresh.py
@@ -96,7 +96,7 @@ class RefreshResult:
         ca_cert, cert_chain = certs
         # get expiration from client certificate
         cert_obj = x509.load_pem_x509_certificate(cert_chain[0].encode("UTF-8"))
-        self.expiration = cert_obj.not_valid_after.replace(tzinfo=timezone.utc)
+        self.expiration = cert_obj.not_valid_after_utc
 
         # tmpdir and its contents are automatically deleted after the CA cert
         # and cert chain are loaded into the SSLcontext. The values

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ description = "A Python client library for connecting securely to your Google Cl
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
     "aiohttp",
-    "cryptography>=38.0.3",
+    "cryptography>=42.0.0",
     "requests",
     "google-auth",
     "protobuf",


### PR DESCRIPTION
In cryptography v42.0.0 the `not_valid_after_utc` field was added to certs. This allows us to pull the aware datetime cert expiry instead of the naive one which is slowly being deprecated.

This will help to remove a deprecation warning that is currently being outputted:
```
alloydb-python-connector/google/cloud/alloydb/connector/refresh.py:99: CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_after_utc.
  self.expiration = cert_obj.not_valid_after.replace(tzinfo=timezone.utc)
```

Closes #206 