### PR TITLE
docs: Use AlloyDB API for consistency with the official documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This package requires the following to connect successfully:
   Client][client-role] role or equivalent. [Credentials](#credentials)
   for the IAM principal are used to authorize connections to an AlloyDB instance.
 
-* The [AlloyDB Admin API][admin-api] to be enabled within your Google Cloud
+* The [AlloyDB API][admin-api] to be enabled within your Google Cloud
   Project. By default, the API will be called in the project associated with the
   IAM principal.
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ This package requires the following to connect successfully:
   Client][client-role] role or equivalent. [Credentials](#credentials)
   for the IAM principal are used to authorize connections to an AlloyDB instance.
 
-* The [AlloyDB API][admin-api] to be enabled within your Google Cloud
+* The [AlloyDB API][alloydb-api] to be enabled within your Google Cloud
   Project. By default, the API will be called in the project associated with the
   IAM principal.
 
-[admin-api]:   https://console.cloud.google.com/apis/api/alloydb.googleapis.com
+[alloydb-api]: https://console.cloud.google.com/apis/api/alloydb.googleapis.com
 [client-role]: https://cloud.google.com/alloydb/docs/auth-proxy/overview#how-authorized
 
 ### Credentials

--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -56,7 +56,7 @@ class AlloyDBClient:
         user_agent: Optional[str] = None,
     ) -> None:
         """
-        Establish the client to be used for AlloyDB Admin API requests.
+        Establish the client to be used for AlloyDB API requests.
 
         Args:
             alloydb_api_endpoint (str): Base URL to use when calling
@@ -69,7 +69,7 @@ class AlloyDBClient:
                 Must have the AlloyDB Admin scopes. For more info check out
                 https://google-auth.readthedocs.io/en/latest/.
             client (aiohttp.ClientSession): Async client used to make requests to
-                AlloyDB Admin APIs.
+                AlloyDB APIs.
                 Optional, defaults to None and creates new client.
             driver (str): Database driver to be used by the client.
         """
@@ -100,7 +100,7 @@ class AlloyDBClient:
         """
         Fetch the metadata for a given AlloyDB instance.
 
-        Call the AlloyDB Admin APIs connectInfo method to retrieve the
+        Call the AlloyDB APIs connectInfo method to retrieve the
         information about an AlloyDB instance that is used to create secure
         connections.
 
@@ -144,7 +144,7 @@ class AlloyDBClient:
         """
         Fetch a client certificate for the given AlloyDB cluster.
 
-        Call the AlloyDB Admin API's generateClientCertificate
+        Call the AlloyDB API's generateClientCertificate
         method to create a signed TLS certificate that is authorized to connect via the
         AlloyDB instance's serverside proxy. The cert is valid for twenty-four hours.
 

--- a/google/cloud/alloydb/connector/instance.py
+++ b/google/cloud/alloydb/connector/instance.py
@@ -71,14 +71,14 @@ class Instance:
     """
     Manages the information used to connect to the AlloyDB instance.
 
-    Periodically calls the AlloyDB Admin API, automatically refreshing the
+    Periodically calls the AlloyDB API, automatically refreshing the
     required information approximately 4 minutes before the previous
     certificate expires (every ~56 minutes).
 
     Args:
         instance_uri (str): The instance URI of the AlloyDB instance.
             ex. projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE>
-        client (AlloyDBClient): Client used to make requests to AlloyDB Admin APIs.
+        client (AlloyDBClient): Client used to make requests to AlloyDB APIs.
         keys (Tuple[rsa.RSAPrivateKey, str]): Private and Public key pair.
     """
 


### PR DESCRIPTION
We received feedback from customers indicating confusion regarding the usage of `AlloyDB Admin API` in our documentation. To address this, we are updating the API reference to `AlloyDB API`, as recommended in the [official documentation](https://cloud.google.com/alloydb/docs/reference/rest).