### PR TITLE
chore: verify custom user agent is type str

### DIFF
--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -39,7 +39,7 @@ def _format_user_agent(
     Appends user-defined user agents to the base default agent.
     """
     agent = f"{USER_AGENT}+{driver}" if driver else USER_AGENT
-    if custom_user_agent:
+    if custom_user_agent and isinstance(custom_user_agent, str):
         agent = f"{agent} {custom_user_agent}"
 
     return agent


### PR DESCRIPTION
If custom user agent is not of type `str`, do not use it and use default user agent.

Port of https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/pull/1052