### PR TITLE
chore: install asyncio version of SQLAlchemy for tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,4 +6,4 @@ pytest==8.1.1
 pytest-asyncio==0.23.6
 pytest-cov==5.0.0
 pytest-aiohttp==1.0.5
-SQLAlchemy==2.0.29
+SQLAlchemy[asyncio]==2.0.29


### PR DESCRIPTION
To guarantee macOS environments will work for the async SQLAlchemy engines (asyncpg usage) we should be installing the `sqlalchemy[asyncio]`  extra dependencies.

Ref: https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#asyncio-platform-installation-notes-including-apple-m1