### PR TITLE
chore: remove destructor from connector.py

### DIFF
--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -333,7 +333,3 @@ class Connector:
         )
         if self._client:
             await self._client.close()
-
-    def __del__(self) -> None:
-        """Close Connector as part of garbage collection"""
-        self.close()


### PR DESCRIPTION
Remove __del__ destructor for Connector as it seems to be causing timeout errors.

Related to https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/pull/1010.