### PR TITLE
refactor: use google.auth TokenState for credentials validity

### DIFF
--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -18,7 +18,6 @@ import logging
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import aiohttp
-from google.auth.transport.requests import Request
 
 from google.cloud.alloydb.connector.version import __version__ as version
 
@@ -116,10 +115,6 @@ class AlloyDBClient:
         """
         logger.debug(f"['{project}/{region}/{cluster}/{name}']: Requesting metadata")
 
-        if not self._credentials.valid:
-            request = Request()
-            self._credentials.refresh(request)
-
         headers = {
             "Authorization": f"Bearer {self._credentials.token}",
         }
@@ -166,10 +161,6 @@ class AlloyDBClient:
                 and certificate chain for the AlloyDB instance.
         """
         logger.debug(f"['{project}/{region}/{cluster}']: Requesting client certificate")
-
-        if not self._credentials.valid:
-            request = Request()
-            self._credentials.refresh(request)
 
         headers = {
             "Authorization": f"Bearer {self._credentials.token}",


### PR DESCRIPTION
In the google.auth package, it is now recommended to use `.token_state`
over `.valid` for checking validity of credentials.

Token state gives more information such as if token is stale, expired,
invalid etc.

`.valid` is now marked as deprecated ([code](https://github.com/googleapis/google-auth-library-python/blob/main/google/auth/credentials.py#L87C5-L97C59)):
```python
@property
def valid(self):
    """Checks the validity of the credentials.

    This is True if the credentials have a :attr:`token` and the token
    is not :attr:`expired`.

    .. deprecated:: v2.24.0
      Prefer checking :attr:`token_state` instead.
    """
    return self.token is not None and not self.expired
```

Closes #286 

Should also unblock #245 