### PR TITLE
refactor: rename Instance to RefreshAheadCache

### DIFF
--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -24,8 +24,8 @@ import google.auth.transport.requests
 
 import google.cloud.alloydb.connector.asyncpg as asyncpg
 from google.cloud.alloydb.connector.client import AlloyDBClient
-from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.instance import IPTypes
+from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.utils import generate_keys
 
 if TYPE_CHECKING:

--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -24,7 +24,7 @@ import google.auth.transport.requests
 
 import google.cloud.alloydb.connector.asyncpg as asyncpg
 from google.cloud.alloydb.connector.client import AlloyDBClient
-from google.cloud.alloydb.connector.instance import Instance
+from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.instance import IPTypes
 from google.cloud.alloydb.connector.utils import generate_keys
 
@@ -60,7 +60,7 @@ class AsyncConnector:
         ip_type: str | IPTypes = IPTypes.PRIVATE,
         user_agent: Optional[str] = None,
     ) -> None:
-        self._instances: Dict[str, Instance] = {}
+        self._instances: Dict[str, RefreshAheadCache] = {}
         # initialize default params
         self._quota_project = quota_project
         self._alloydb_api_endpoint = alloydb_api_endpoint
@@ -128,7 +128,7 @@ class AsyncConnector:
         if instance_uri in self._instances:
             instance = self._instances[instance_uri]
         else:
-            instance = Instance(instance_uri, self._client, self._keys)
+            instance = RefreshAheadCache(instance_uri, self._client, self._keys)
             self._instances[instance_uri] = instance
 
         connect_func = {
@@ -186,7 +186,7 @@ class AsyncConnector:
         await self.close()
 
     async def close(self) -> None:
-        """Helper function to cancel Instances' tasks
+        """Helper function to cancel RefreshAheadCaches' tasks
         and close client."""
         await asyncio.gather(
             *[instance.close() for instance in self._instances.values()]

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -26,7 +26,7 @@ from google.auth import default
 from google.auth.credentials import with_scopes_if_required
 
 from google.cloud.alloydb.connector.client import AlloyDBClient
-from google.cloud.alloydb.connector.instance import Instance
+from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.instance import IPTypes
 import google.cloud.alloydb.connector.pg8000 as pg8000
 from google.cloud.alloydb.connector.utils import generate_keys
@@ -74,7 +74,7 @@ class Connector:
         self._loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
         self._thread = Thread(target=self._loop.run_forever, daemon=True)
         self._thread.start()
-        self._instances: Dict[str, Instance] = {}
+        self._instances: Dict[str, RefreshAheadCache] = {}
         # initialize default params
         self._quota_project = quota_project
         self._alloydb_api_endpoint = alloydb_api_endpoint
@@ -152,11 +152,11 @@ class Connector:
             )
         enable_iam_auth = kwargs.pop("enable_iam_auth", self._enable_iam_auth)
         # use existing connection info if possible
-        if instance_uri in self._instances:
-            instance = self._instances[instance_uri]
+        if instance_uri in self._cache:
+            cache = self._cache[instance_uri]
         else:
-            instance = Instance(instance_uri, self._client, self._keys)
-            self._instances[instance_uri] = instance
+            cache = RefreshAheadCache(instance_uri, self._client, self._keys)
+            self._instances[instance_uri] = cache
 
         connect_func = {
             "pg8000": pg8000.connect,
@@ -178,7 +178,7 @@ class Connector:
         # if ip_type is str, convert to IPTypes enum
         if isinstance(ip_type, str):
             ip_type = IPTypes(ip_type.upper())
-        ip_address, context = await instance.connection_info(ip_type)
+        ip_address, context = await cache.connection_info(ip_type)
 
         # synchronous drivers are blocking and run using executor
         try:
@@ -190,7 +190,7 @@ class Connector:
             return await self._loop.run_in_executor(None, connect_partial)
         except Exception:
             # we attempt a force refresh, then throw the error
-            await instance.force_refresh()
+            await cache.force_refresh()
             raise
 
     def metadata_exchange(
@@ -326,10 +326,8 @@ class Connector:
             self._thread.join()
 
     async def close_async(self) -> None:
-        """Helper function to cancel Instances' tasks
+        """Helper function to cancel RefreshAheadCaches' tasks
         and close client."""
-        await asyncio.gather(
-            *[instance.close() for instance in self._instances.values()]
-        )
+        await asyncio.gather(*[cache.close() for cache in self._cache.values()])
         if self._client:
             await self._client.close()

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -74,7 +74,7 @@ class Connector:
         self._loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
         self._thread = Thread(target=self._loop.run_forever, daemon=True)
         self._thread.start()
-        self._instances: Dict[str, RefreshAheadCache] = {}
+        self._cache: Dict[str, RefreshAheadCache] = {}
         # initialize default params
         self._quota_project = quota_project
         self._alloydb_api_endpoint = alloydb_api_endpoint

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -26,8 +26,8 @@ from google.auth import default
 from google.auth.credentials import with_scopes_if_required
 
 from google.cloud.alloydb.connector.client import AlloyDBClient
-from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.instance import IPTypes
+from google.cloud.alloydb.connector.instance import RefreshAheadCache
 import google.cloud.alloydb.connector.pg8000 as pg8000
 from google.cloud.alloydb.connector.utils import generate_keys
 import google.cloud.alloydb_connectors_v1.proto.resources_pb2 as connectorspb

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -156,7 +156,7 @@ class Connector:
             cache = self._cache[instance_uri]
         else:
             cache = RefreshAheadCache(instance_uri, self._client, self._keys)
-            self._instances[instance_uri] = cache
+            self._cache[instance_uri] = cache
 
         connect_func = {
             "pg8000": pg8000.connect,

--- a/google/cloud/alloydb/connector/instance.py
+++ b/google/cloud/alloydb/connector/instance.py
@@ -78,7 +78,7 @@ def _parse_instance_uri(instance_uri: str) -> Tuple[str, str, str, str]:
     )
 
 
-class Instance:
+class RefreshAheadCache:
     """
     Manages the information used to connect to the AlloyDB instance.
 

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -24,8 +24,8 @@ import pytest
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.exceptions import RefreshError
 from google.cloud.alloydb.connector.instance import _parse_instance_uri
-from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.instance import IPTypes
+from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.refresh import _is_valid
 from google.cloud.alloydb.connector.refresh import RefreshResult
 from google.cloud.alloydb.connector.utils import generate_keys


### PR DESCRIPTION
Rename `Instance` to `RefreshAheadCache` to get ready for adding a
`LazyRefreshCache` type in the future. This will improve naming so customers
are not confused by `Instance` not reflecting an AlloyDB instance and instead
being a cache of connection info to connect to an AlloyDB instance.

Port of https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/pull/1068