### PR TITLE
refactor: update AlloyDBClient and ConnectionInfo classes

### DIFF
--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -60,7 +60,7 @@ class AsyncConnector:
         ip_type: str | IPTypes = IPTypes.PRIVATE,
         user_agent: Optional[str] = None,
     ) -> None:
-        self._instances: Dict[str, RefreshAheadCache] = {}
+        self._cache: Dict[str, RefreshAheadCache] = {}
         # initialize default params
         self._quota_project = quota_project
         self._alloydb_api_endpoint = alloydb_api_endpoint
@@ -125,11 +125,11 @@ class AsyncConnector:
         enable_iam_auth = kwargs.pop("enable_iam_auth", self._enable_iam_auth)
 
         # use existing connection info if possible
-        if instance_uri in self._instances:
-            instance = self._instances[instance_uri]
+        if instance_uri in self._cache:
+            cache = self._cache[instance_uri]
         else:
-            instance = RefreshAheadCache(instance_uri, self._client, self._keys)
-            self._instances[instance_uri] = instance
+            cache = RefreshAheadCache(instance_uri, self._client, self._keys)
+            self._cache[instance_uri] = cache
 
         connect_func = {
             "asyncpg": asyncpg.connect,
@@ -151,7 +151,8 @@ class AsyncConnector:
         # if ip_type is str, convert to IPTypes enum
         if isinstance(ip_type, str):
             ip_type = IPTypes(ip_type.upper())
-        ip_address, context = await instance.connection_info(ip_type)
+        conn_info = await cache.connect_info()
+        ip_address = conn_info.get_preferred_ip(ip_type)
 
         # callable to be used for auto IAM authn
         def get_authentication_token() -> str:
@@ -166,10 +167,10 @@ class AsyncConnector:
         if enable_iam_auth:
             kwargs["password"] = get_authentication_token
         try:
-            return await connector(ip_address, context, **kwargs)
+            return await connector(ip_address, conn_info.create_ssl_context(), **kwargs)
         except Exception:
             # we attempt a force refresh, then throw the error
-            await instance.force_refresh()
+            await cache.force_refresh()
             raise
 
     async def __aenter__(self) -> Any:
@@ -188,8 +189,6 @@ class AsyncConnector:
     async def close(self) -> None:
         """Helper function to cancel RefreshAheadCaches' tasks
         and close client."""
-        await asyncio.gather(
-            *[instance.close() for instance in self._instances.values()]
-        )
+        await asyncio.gather(*[cache.close() for cache in self._cache.values()])
         if self._client:
             await self._client.close()

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -178,12 +178,17 @@ class Connector:
         # if ip_type is str, convert to IPTypes enum
         if isinstance(ip_type, str):
             ip_type = IPTypes(ip_type.upper())
-        ip_address, context = await cache.connection_info(ip_type)
+        conn_info = await cache.connect_info()
+        ip_address = conn_info.get_preferred_ip(ip_type)
 
         # synchronous drivers are blocking and run using executor
         try:
             metadata_partial = partial(
-                self.metadata_exchange, ip_address, context, enable_iam_auth, driver
+                self.metadata_exchange,
+                ip_address,
+                conn_info.create_ssl_context(),
+                enable_iam_auth,
+                driver,
             )
             sock = await self._loop.run_in_executor(None, metadata_partial)
             connect_partial = partial(connector, sock, **kwargs)

--- a/tests/unit/test_connection_info.py
+++ b/tests/unit/test_connection_info.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -21,9 +22,15 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from mocks import FakeAlloyDBClient
 from mocks import FakeInstance
+import pytest
 
 from google.cloud.alloydb.connector.connection_info import ConnectionInfo
+from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
+from google.cloud.alloydb.connector.instance import IPTypes
+from google.cloud.alloydb.connector.instance import RefreshAheadCache
+from google.cloud.alloydb.connector.utils import generate_keys
 
 
 def test_ConnectionInfo_init_(fake_instance: FakeInstance) -> None:
@@ -48,7 +55,76 @@ def test_ConnectionInfo_init_(fake_instance: FakeInstance) -> None:
     client_cert = client_cert.public_bytes(encoding=serialization.Encoding.PEM).decode(
         "UTF-8"
     )
-    certs = (ca_cert, [client_cert, intermediate_cert, root_cert])
-    refresh = ConnectionInfo(fake_instance.ip_addrs, key, certs)
+    conn_info = ConnectionInfo(
+        [client_cert, intermediate_cert, root_cert],
+        ca_cert,
+        key,
+        fake_instance.ip_addrs,
+        datetime.now(timezone.utc) + timedelta(minutes=10),
+    )
+    context = conn_info.create_ssl_context()
     # verify TLS requirements
-    assert refresh.context.minimum_version == ssl.TLSVersion.TLSv1_3
+    assert context.minimum_version == ssl.TLSVersion.TLSv1_3
+
+
+def test_ConnectionInfo_caches_sslcontext() -> None:
+    info = ConnectionInfo(["cert"], "cert", "key".encode(), {}, datetime.now())
+    # context should default to None
+    assert info.context is None
+    # cache a 'context'
+    info.context = "context"
+    # caling create_ssl_context should no-op with an existing 'context'
+    info.create_ssl_context()
+    assert info.context == "context"
+
+
+@pytest.mark.parametrize(
+    "ip_type, expected",
+    [
+        (
+            IPTypes.PRIVATE,
+            "127.0.0.1",
+        ),
+        (
+            IPTypes.PUBLIC,
+            "0.0.0.0",
+        ),
+        (
+            IPTypes.PSC,
+            "x.y.alloydb.goog",
+        ),
+    ],
+)
+async def test_ConnectionInfo_get_preferred_ip(ip_type: IPTypes, expected: str) -> None:
+    """Test that ConnectionInfo.get_preferred_ip returns proper ip address."""
+    keys = asyncio.create_task(generate_keys())
+    client = FakeAlloyDBClient()
+    cache = RefreshAheadCache(
+        "projects/test-project/locations/test-region/clusters/test-cluster/instances/test-instance",
+        client,
+        keys,
+    )
+    conn_info = await cache.connect_info()
+    ip_address = conn_info.get_preferred_ip(ip_type)
+    assert ip_address == expected
+    # close instance
+    await cache.close()
+
+
+async def test_ConnectionInfo_get_preferred_ip_IPTypeNotFoundError() -> None:
+    """Test that ConnectionInfo.get_preferred_ip throws IPTypeNotFoundError"""
+    keys = asyncio.create_task(generate_keys())
+    client = FakeAlloyDBClient()
+    # set ip_addrs to have no public IP
+    client.instance.ip_addrs = {"PRIVATE": "10.0.0.1"}
+    cache = RefreshAheadCache(
+        "projects/test-project/locations/test-region/clusters/test-cluster/instances/test-instance",
+        client,
+        keys,
+    )
+    conn_info = await cache.connect_info()
+    # check RefreshError is thrown
+    with pytest.raises(IPTypeNotFoundError):
+        conn_info.get_preferred_ip(ip_type=IPTypes.PUBLIC)
+    # close instance
+    await cache.close()

--- a/tests/unit/test_connection_info.py
+++ b/tests/unit/test_connection_info.py
@@ -114,6 +114,6 @@ async def test_ConnectionInfo_get_preferred_ip_IPTypeNotFoundError() -> None:
         {},
         datetime.now(timezone.utc),
     )
-    # check RefreshError is thrown
+    # check error is thrown
     with pytest.raises(IPTypeNotFoundError):
         conn_info.get_preferred_ip(ip_type=IPTypes.PUBLIC)

--- a/tests/unit/test_connection_info.py
+++ b/tests/unit/test_connection_info.py
@@ -73,7 +73,7 @@ def test_ConnectionInfo_caches_sslcontext() -> None:
     assert info.context is None
     # cache a 'context'
     info.context = "context"
-    # caling create_ssl_context should no-op with an existing 'context'
+    # calling create_ssl_context should no-op with an existing 'context'
     info.create_ssl_context()
     assert info.context == "context"
 

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -22,10 +22,8 @@ from mocks import FakeAlloyDBClient
 import pytest
 
 from google.cloud.alloydb.connector.connection_info import ConnectionInfo
-from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.exceptions import RefreshError
 from google.cloud.alloydb.connector.instance import _parse_instance_uri
-from google.cloud.alloydb.connector.instance import IPTypes
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.refresh_utils import _is_valid
 from google.cloud.alloydb.connector.utils import generate_keys
@@ -140,58 +138,6 @@ async def test_perform_refresh() -> None:
         "PSC": "x.y.alloydb.goog",
     }
     assert refresh.expiration == client.instance.cert_expiry.replace(microsecond=0)
-    # close instance
-    await cache.close()
-
-
-@pytest.mark.parametrize(
-    "ip_type, expected",
-    [
-        (
-            IPTypes.PRIVATE,
-            "127.0.0.1",
-        ),
-        (
-            IPTypes.PUBLIC,
-            "0.0.0.0",
-        ),
-        (
-            IPTypes.PSC,
-            "x.y.alloydb.goog",
-        ),
-    ],
-)
-@pytest.mark.asyncio
-async def test_connection_info(ip_type: IPTypes, expected: str) -> None:
-    """Test that connection_info returns proper ip address."""
-    keys = asyncio.create_task(generate_keys())
-    client = FakeAlloyDBClient()
-    cache = RefreshAheadCache(
-        "projects/test-project/locations/test-region/clusters/test-cluster/instances/test-instance",
-        client,
-        keys,
-    )
-    ip_address, _ = await cache.connection_info(ip_type=ip_type)
-    assert ip_address == expected
-    # close instance
-    await cache.close()
-
-
-@pytest.mark.asyncio
-async def test_connection_info_IPTypeNotFoundError() -> None:
-    """Test that connection_info throws IPTypeNotFoundError"""
-    keys = asyncio.create_task(generate_keys())
-    client = FakeAlloyDBClient()
-    # set ip_addrs to have no public IP
-    client.instance.ip_addrs = {"PRIVATE": "10.0.0.1"}
-    cache = RefreshAheadCache(
-        "projects/test-project/locations/test-region/clusters/test-cluster/instances/test-instance",
-        client,
-        keys,
-    )
-    # check RefreshError is thrown
-    with pytest.raises(IPTypeNotFoundError):
-        await cache.connection_info(ip_type=IPTypes.PUBLIC)
     # close instance
     await cache.close()
 


### PR DESCRIPTION
Refactor of `AlloyDBClient` and `ConnectionInfo` classes.

Added the `get_connection_info` method to the AlloyDBClient.
This method does an immediate refresh and calls the AlloyDB APIs 
to get a fresh `ConnectionInfo`. This allows better encapsulation.

Refactored `ConnectionInfo` to a dataclass and added two new methods;
`create_ssl_context` and `get_preferred_ip`. Moved all SSL/TLS configuration
within `create_ssl_context`. This way ConnectionInfo() prepares all the info
required to connect and then `create_ssl_context` will use the info to establish
the SSL/TLS connection when called from `Connector.connect` at the time of
connection.

Port of https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/pull/1079 and https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/pull/1090

Related to #298 