### PR TITLE
refactor: move shared enums to enums.py

### DIFF
--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -24,7 +24,7 @@ import google.auth.transport.requests
 
 import google.cloud.alloydb.connector.asyncpg as asyncpg
 from google.cloud.alloydb.connector.client import AlloyDBClient
-from google.cloud.alloydb.connector.instance import IPTypes
+from google.cloud.alloydb.connector.enums import IPTypes
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.utils import generate_keys
 

--- a/google/cloud/alloydb/connector/connection_info.py
+++ b/google/cloud/alloydb/connector/connection_info.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
     from cryptography.hazmat.primitives.asymmetric import rsa
 
-    from google.cloud.alloydb.connector.instance import IPTypes
+    from google.cloud.alloydb.connector.enums import IPTypes
 
 logger = logging.getLogger(name=__name__)
 

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -26,7 +26,7 @@ from google.auth import default
 from google.auth.credentials import with_scopes_if_required
 
 from google.cloud.alloydb.connector.client import AlloyDBClient
-from google.cloud.alloydb.connector.instance import IPTypes
+from google.cloud.alloydb.connector.enums import IPTypes
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 import google.cloud.alloydb.connector.pg8000 as pg8000
 from google.cloud.alloydb.connector.utils import generate_keys

--- a/google/cloud/alloydb/connector/enums.py
+++ b/google/cloud/alloydb/connector/enums.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from google.cloud.alloydb.connector.async_connector import AsyncConnector
-from google.cloud.alloydb.connector.connector import Connector
-from google.cloud.alloydb.connector.enums import IPTypes
-from google.cloud.alloydb.connector.version import __version__
 
-__all__ = ["__version__", "Connector", "AsyncConnector", "IPTypes"]
+from enum import Enum
+
+
+class IPTypes(Enum):
+    """
+    Enum for specifying IP type to connect to AlloyDB with.
+    """
+
+    PUBLIC: str = "PUBLIC"
+    PRIVATE: str = "PRIVATE"
+    PSC: str = "PSC"
+
+    @classmethod
+    def _missing_(cls, value: object) -> None:
+        raise ValueError(
+            f"Incorrect value for ip_type, got '{value}'. Want one of: "
+            f"{', '.join([repr(m.value) for m in cls])}."
+        )

--- a/google/cloud/alloydb/connector/instance.py
+++ b/google/cloud/alloydb/connector/instance.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import asyncio
-from enum import Enum
 import logging
 import re
 from typing import Tuple, TYPE_CHECKING
@@ -36,23 +35,6 @@ logger = logging.getLogger(name=__name__)
 INSTANCE_URI_REGEX = re.compile(
     "projects/([^:]+(:[^:]+)?)/locations/([^:]+)/clusters/([^:]+)/instances/([^:]+)"
 )
-
-
-class IPTypes(Enum):
-    """
-    Enum for specifying IP type to connect to AlloyDB with.
-    """
-
-    PUBLIC: str = "PUBLIC"
-    PRIVATE: str = "PRIVATE"
-    PSC: str = "PSC"
-
-    @classmethod
-    def _missing_(cls, value: object) -> None:
-        raise ValueError(
-            f"Incorrect value for ip_type, got '{value}'. Want one of: "
-            f"{', '.join([repr(m.value) for m in cls])}."
-        )
 
 
 def _parse_instance_uri(instance_uri: str) -> Tuple[str, str, str, str]:

--- a/tests/unit/test_connection_info.py
+++ b/tests/unit/test_connection_info.py
@@ -24,9 +24,9 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from mocks import FakeInstance
 import pytest
 
+from google.cloud.alloydb.connector import IPTypes
 from google.cloud.alloydb.connector.connection_info import ConnectionInfo
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
-from google.cloud.alloydb.connector.instance import IPTypes
 
 
 def test_ConnectionInfo_init_(fake_instance: FakeInstance) -> None:


### PR DESCRIPTION
Moving all shared enums such as `IPTypes` into `enums.py` as lazy
refresh will add another enum to be shared.