### PR TITLE
feat: add standardized debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,28 @@ pool = sqlalchemy.create_engine(
 connector.close()
 ```
 
+### Debug Logging
+
+The AlloyDB Python Connector uses the standard [Python logging module][python-logging]
+for debug logging support.
+
+Add the below code to your application to enable debug logging with the AlloyDB
+Python Connector:
+
+```python
+import logging
+
+logging.basicConfig(format="%(asctime)s [%(levelname)s]: %(message)s")
+logger = logging.getLogger(name="google.cloud.alloydb.connector")
+logger.setLevel(logging.DEBUG)
+```
+
+For more details on configuring logging, please refer to the
+[Python logging docs][configure-logging].
+
+[python-logging]: https://docs.python.org/3/library/logging.html
+[configure-logging]: https://docs.python.org/3/howto/logging.html#configuring-logging
+
 ## Support policy
 
 ### Major version lifecycle

--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -118,8 +118,6 @@ class AlloyDBClient:
         Returns:
             dict: IP addresses of the AlloyDB instance.
         """
-        logger.debug(f"['{project}/{region}/{cluster}/{name}']: Requesting metadata")
-
         headers = {
             "Authorization": f"Bearer {self._credentials.token}",
         }
@@ -165,8 +163,6 @@ class AlloyDBClient:
             Tuple[str, list[str]]: Tuple containing the CA certificate
                 and certificate chain for the AlloyDB instance.
         """
-        logger.debug(f"['{project}/{region}/{cluster}']: Requesting client certificate")
-
         headers = {
             "Authorization": f"Bearer {self._credentials.token}",
         }
@@ -252,4 +248,6 @@ class AlloyDBClient:
 
     async def close(self) -> None:
         """Close AlloyDBClient gracefully."""
+        logger.debug("Waiting for connector's http client to close")
         await self._client.close()
+        logger.debug("Closed connector's http client")


### PR DESCRIPTION
Standardize optional debug logging across AlloyDB Connector packages.

To print debug logs for the Python Connector package add the following to your application:

```python
import logging

logging.basicConfig(format="%(asctime)s [%(levelname)s]: %(message)s")
logger = logging.getLogger(name="google.cloud.alloydb.connector")
logger.setLevel(logging.DEBUG)
```

Example of the debug logs produced:

```sh
2024-07-24 17:52:05,231 [DEBUG]: ['projects/my-proj/locations/us-central1/clusters/my-cluster/instances/my-instance']: Refresh strategy is set to background refresh
2024-07-24 17:52:05,231 [DEBUG]: ['projects/my-proj/locations/us-central1/clusters/my-cluster/instances/my-instance']: Connection info added to cache
2024-07-24 17:52:05,231 [DEBUG]: ['projects/my-proj/locations/us-central1/clusters/my-cluster/instances/my-instance']: Connection info refresh operation started
2024-07-24 17:52:05,881 [DEBUG]: ['projects/my-proj/locations/us-central1/clusters/my-cluster/instances/my-instance']: Connection info refresh operation complete
2024-07-24 17:52:05,882 [DEBUG]: ['projects/my-proj/locations/us-central1/clusters/my-cluster/instances/my-instance']: Current certificate expiration = 2024-07-24T18:52:04+00:00
2024-07-24 17:52:05,882 [DEBUG]: ['projects/my-proj/locations/us-central1/clusters/my-cluster/instances/my-instance']: Connection info refresh operation scheduled for 2024-07-24T18:22:06+00:00 (now + 0:30:01)
2024-07-24 17:52:05,882 [DEBUG]: ['projects/my-proj/locations/us-central1/clusters/my-cluster/instances/my-instance']: Connecting to 127.0.0.1:5433
2024-07-24 17:52:06,458 [DEBUG]: ['projects/my-proj/locations/us-central1/clusters/my-cluster/instances/my-instance']: Canceling connection info refresh operation tasks
2024-07-24 17:52:06,458 [DEBUG]: ['projects/my-proj/locations/us-central1/clusters/my-cluster/instances/my-instance']: Scheduled refresh operation cancelled
2024-07-24 17:52:06,458 [DEBUG]: Waiting for connector's http client to close
2024-07-24 17:52:06,459 [DEBUG]: Closed connector's http client
```

Currently debug logging the following:
- When a refresh operation starts
- When a refresh operation finishes
- When a refresh operation errors
- When a refresh operation is canceled
- The ephemeral certificate’s expiration time
- The next scheduled refresh
- Adding connection info to the cache
- The IP address connection is being made to

Fixes #272 