### PR TITLE
fix: remove default argument `now` from `_seconds_until_refresh` 

### DIFF
--- a/google/cloud/alloydb/connector/instance.py
+++ b/google/cloud/alloydb/connector/instance.py
@@ -197,9 +197,7 @@ class RefreshAheadCache:
         # if valid refresh, replace current with valid refresh result and schedule next refresh
         self._current = refresh_task
         # calculate refresh delay based on certificate expiration
-        delay = _seconds_until_refresh(
-            refresh_result.expiration, datetime.now(timezone.utc)
-        )
+        delay = _seconds_until_refresh(refresh_result.expiration)
         logger.debug(
             f"['{self._instance_uri}']: Connection info refresh operation"
             " scheduled for "

--- a/google/cloud/alloydb/connector/instance.py
+++ b/google/cloud/alloydb/connector/instance.py
@@ -197,7 +197,9 @@ class RefreshAheadCache:
         # if valid refresh, replace current with valid refresh result and schedule next refresh
         self._current = refresh_task
         # calculate refresh delay based on certificate expiration
-        delay = _seconds_until_refresh(refresh_result.expiration)
+        delay = _seconds_until_refresh(
+            refresh_result.expiration, datetime.now(timezone.utc)
+        )
         logger.debug(
             f"['{self._instance_uri}']: Connection info refresh operation"
             " scheduled for "

--- a/google/cloud/alloydb/connector/refresh_utils.py
+++ b/google/cloud/alloydb/connector/refresh_utils.py
@@ -26,9 +26,7 @@ logger = logging.getLogger(name=__name__)
 _refresh_buffer: int = 4 * 60  # 4 minutes
 
 
-def _seconds_until_refresh(
-    expiration: datetime, now: datetime = datetime.now(timezone.utc)
-) -> int:
+def _seconds_until_refresh(expiration: datetime) -> int:
     """
     Calculates the duration to wait before starting the next refresh.
     Usually the duration will be half of the time until certificate
@@ -36,12 +34,11 @@ def _seconds_until_refresh(
 
     Args:
         expiration (datetime.datetime): Time of certificate expiration.
-        now (datetime.datetime): Current time (UTC)
     Returns:
         int: Time in seconds to wait before performing next refresh.
     """
 
-    duration = int((expiration - now).total_seconds())
+    duration = int((expiration - datetime.now(timezone.utc)).total_seconds())
 
     # if certificate duration is less than 1 hour
     if duration < 3600:

--- a/tests/unit/test_refresh_utils.py
+++ b/tests/unit/test_refresh_utils.py
@@ -16,6 +16,8 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
+import pytest
+
 from google.cloud.alloydb.connector.refresh_utils import _seconds_until_refresh
 
 
@@ -24,8 +26,14 @@ def test_seconds_until_refresh_over_1_hour() -> None:
     Test _seconds_until_refresh returns proper time in seconds.
     If expiration is over 1 hour, should return duration/2.
     """
-    now = datetime.now()
-    assert _seconds_until_refresh(now + timedelta(minutes=62), now) == 31 * 60
+    # using pytest.approx since sometimes can be off by a second
+    assert (
+        pytest.approx(
+            _seconds_until_refresh(datetime.now(timezone.utc) + timedelta(minutes=62)),
+            1,
+        )
+        == 31 * 60
+    )
 
 
 def test_seconds_until_refresh_under_1_hour_over_4_mins() -> None:
@@ -34,8 +42,14 @@ def test_seconds_until_refresh_under_1_hour_over_4_mins() -> None:
     If expiration is under 1 hour and over 4 minutes,
     should return duration-refresh_buffer (refresh_buffer = 4 minutes).
     """
-    now = datetime.now(timezone.utc)
-    assert _seconds_until_refresh(now + timedelta(minutes=5), now) == 60
+    # using pytest.approx since sometimes can be off by a second
+    assert (
+        pytest.approx(
+            _seconds_until_refresh(datetime.now(timezone.utc) + timedelta(minutes=5)),
+            1,
+        )
+        == 60
+    )
 
 
 def test_seconds_until_refresh_under_4_mins() -> None:


### PR DESCRIPTION
`_seconds_until_refresh` which is used for background refresh strategy
(lazy refresh is unaffected!) should not have `now` as a default argument
due to Python only evaluating default arguments once at function definition.
 
 > Python's default arguments are evaluated only once when the function
is defined, not each time the function is called. ([source](https://www.codecademy.com/learn/learn-intermediate-python-3/modules/int-python-function-arguments/cheatsheet))

Problematic code: https://github.com/GoogleCloudPlatform/alloydb-python-connector/blob/14d6b1c291766eddf9110927ad726892a0fe9798/google/cloud/alloydb/connector/refresh_utils.py#L29-L53

Having `now` as a default argument means it is set once and then never
adjusted. So in subsequent calls to `_seconds_until_refresh` the `duration`
will just continue to grow larger and larger as it evaluates agains the same `now`

The result of this means that `duration // 2` block is always being hit and
will continue to grow. It could grow to be greater than 3600 and lead to errors.