### PR TITLE
ci: speed up unit test builds

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,6 +57,8 @@ jobs:
 
       - id: 'auth'
         name: Authenticate to Google Cloud
+        # only needed for Flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
         uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
         with:
           workload_identity_provider: ${{ vars.PROVIDER_NAME }}


### PR DESCRIPTION
The `auth` step in unit test builds is only needed for Flakybot,
since Flakybot only runs on `push` and `schedule` events we
can skip auth step for all other events.