### PR TITLE
feat: use non-blocking disk read/writes

### DIFF
--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -194,7 +194,9 @@ class AsyncConnector:
         if enable_iam_auth:
             kwargs["password"] = get_authentication_token
         try:
-            return await connector(ip_address, conn_info.create_ssl_context(), **kwargs)
+            return await connector(
+                ip_address, await conn_info.create_ssl_context(), **kwargs
+            )
         except Exception:
             # we attempt a force refresh, then throw the error
             await cache.force_refresh()

--- a/google/cloud/alloydb/connector/connection_info.py
+++ b/google/cloud/alloydb/connector/connection_info.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import ssl
-from tempfile import TemporaryDirectory
 from typing import Dict, List, Optional, TYPE_CHECKING
+
+from aiofiles.tempfile import TemporaryDirectory
 
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.utils import _write_to_file
@@ -45,7 +46,7 @@ class ConnectionInfo:
     expiration: datetime.datetime
     context: Optional[ssl.SSLContext] = None
 
-    def create_ssl_context(self) -> ssl.SSLContext:
+    async def create_ssl_context(self) -> ssl.SSLContext:
         """Constructs a SSL/TLS context for the given connection info.
 
         Cache the SSL context to ensure we don't read from disk repeatedly when
@@ -66,8 +67,8 @@ class ConnectionInfo:
         # tmpdir and its contents are automatically deleted after the CA cert
         # and cert chain are loaded into the SSLcontext. The values
         # need to be written to files in order to be loaded by the SSLContext
-        with TemporaryDirectory() as tmpdir:
-            ca_filename, cert_chain_filename, key_filename = _write_to_file(
+        async with TemporaryDirectory() as tmpdir:
+            ca_filename, cert_chain_filename, key_filename = await _write_to_file(
                 tmpdir, self.ca_cert, self.cert_chain, self.key
             )
             context.load_cert_chain(cert_chain_filename, keyfile=key_filename)

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -215,7 +215,7 @@ class Connector:
             metadata_partial = partial(
                 self.metadata_exchange,
                 ip_address,
-                conn_info.create_ssl_context(),
+                await conn_info.create_ssl_context(),
                 enable_iam_auth,
                 driver,
             )

--- a/google/cloud/alloydb/connector/utils.py
+++ b/google/cloud/alloydb/connector/utils.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
+import aiofiles
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 
-def _write_to_file(
+async def _write_to_file(
     dir_path: str, ca_cert: str, cert_chain: List[str], key: rsa.RSAPrivateKey
 ) -> Tuple[str, str, str]:
     """
@@ -37,12 +38,12 @@ def _write_to_file(
         encryption_algorithm=serialization.NoEncryption(),
     )
 
-    with open(ca_filename, "w+") as ca_out:
-        ca_out.write(ca_cert)
-    with open(cert_chain_filename, "w+") as chain_out:
-        chain_out.write("".join(cert_chain))
-    with open(key_filename, "wb") as priv_out:
-        priv_out.write(key_bytes)
+    async with aiofiles.open(ca_filename, "w+") as ca_out:
+        await ca_out.write(ca_cert)
+    async with aiofiles.open(cert_chain_filename, "w+") as chain_out:
+        await chain_out.write("".join(cert_chain))
+    async with aiofiles.open(key_filename, "wb") as priv_out:
+        await priv_out.write(key_bytes)
 
     return (ca_filename, cert_chain_filename, key_filename)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles==24.1.0
 aiohttp==3.9.5
 cryptography==42.0.8
 google-auth==2.32.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ description = "A Python client library for connecting securely to your Google Cl
 
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
+    "aiofiles",
     "aiohttp",
     "cryptography>=42.0.0",
     "requests",

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -370,7 +370,7 @@ class FakeConnectionInfo:
         f.set_result("10.0.0.1")
         return f
 
-    def create_ssl_context(self) -> None:
+    async def create_ssl_context(self) -> None:
         return None
 
     async def force_refresh(self) -> None:

--- a/tests/unit/test_connection_info.py
+++ b/tests/unit/test_connection_info.py
@@ -29,7 +29,7 @@ from google.cloud.alloydb.connector.connection_info import ConnectionInfo
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 
 
-def test_ConnectionInfo_init_(fake_instance: FakeInstance) -> None:
+async def test_ConnectionInfo_init_(fake_instance: FakeInstance) -> None:
     """
     Test to check whether the __init__ method of ConnectionInfo
     can correctly initialize TLS context.
@@ -58,19 +58,19 @@ def test_ConnectionInfo_init_(fake_instance: FakeInstance) -> None:
         fake_instance.ip_addrs,
         datetime.now(timezone.utc) + timedelta(minutes=10),
     )
-    context = conn_info.create_ssl_context()
+    context = await conn_info.create_ssl_context()
     # verify TLS requirements
     assert context.minimum_version == ssl.TLSVersion.TLSv1_3
 
 
-def test_ConnectionInfo_caches_sslcontext() -> None:
+async def test_ConnectionInfo_caches_sslcontext() -> None:
     info = ConnectionInfo(["cert"], "cert", "key".encode(), {}, datetime.now())
     # context should default to None
     assert info.context is None
     # cache a 'context'
     info.context = "context"
     # calling create_ssl_context should no-op with an existing 'context'
-    info.create_ssl_context()
+    await info.create_ssl_context()
     assert info.context == "context"
 
 


### PR DESCRIPTION
Currently we use Python's standard library read and writes which are blocking I/O.

This PR switches to use [aiofiles](https://pypi.org/project/aiofiles/) which is non-blocking approach to
read/write to disk.

Closes #359 