### PR TITLE
chore: skip integration tests on forks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,6 +92,11 @@ jobs:
   integration:
     name: integration tests
     runs-on: [self-hosted, linux, x64]
+    # run integration tests on all builds except pull requests from forks or
+    # dependabot
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     strategy:
       matrix:
         python-version: ["3.8", "3.12"]


### PR DESCRIPTION
GitHub provides no reasonable and secure way to run integration tests against PRs from forks. This PR adjusts the CI builds to skip integration tests on PRs from forks and otherwise runs the entire test suite for internal PRs. In addition, integration tests will run on main regardless to catch any regressions.