### PR TITLE
chore: update keystore to a new key

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -23,7 +23,7 @@ python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /
 export PYTHONUNBUFFERED=1
 
 # Move into the package, build the distribution and upload.
-TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google-cloud-pypi-token-keystore-2")
+TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google-cloud-pypi-token-keystore-3")
 cd github/alloydb-python-connector
 python3 setup.py sdist bdist_wheel
 twine upload --username __token__ --password "${TWINE_PASSWORD}" dist/*

--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -46,7 +46,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 73713
-      keyname: "google-cloud-pypi-token-keystore-2"
+      keyname: "google-cloud-pypi-token-keystore-3"
     }
   }
 }


### PR DESCRIPTION
Update the PyPi release token keystore to a new key. It has been rotated again