### PR TITLE
feat: invalidate cache on bad connection info and failed IP lookup

### DIFF
--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -181,8 +181,8 @@ class AsyncConnector:
             conn_info = await cache.connect_info()
             ip_address = conn_info.get_preferred_ip(ip_type)
         except Exception:
-            # with an error from AlloyDB Admin API call or IP type, invalidate
-            # the cache and re-raise the error
+            # with an error from AlloyDB API call or IP type, invalidate the
+            # cache and re-raise the error
             await self._remove_cached(instance_uri)
             raise
         logger.debug(f"['{instance_uri}']: Connecting to {ip_address}:5433")

--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -177,8 +177,14 @@ class AsyncConnector:
         # if ip_type is str, convert to IPTypes enum
         if isinstance(ip_type, str):
             ip_type = IPTypes(ip_type.upper())
-        conn_info = await cache.connect_info()
-        ip_address = conn_info.get_preferred_ip(ip_type)
+        try:
+            conn_info = await cache.connect_info()
+            ip_address = conn_info.get_preferred_ip(ip_type)
+        except Exception:
+            # with an error from AlloyDB Admin API call or IP type, invalidate
+            # the cache and re-raise the error
+            await self._remove_cached(instance_uri)
+            raise
         logger.debug(f"['{instance_uri}']: Connecting to {ip_address}:5433")
 
         # callable to be used for auto IAM authn
@@ -201,6 +207,17 @@ class AsyncConnector:
             # we attempt a force refresh, then throw the error
             await cache.force_refresh()
             raise
+
+    async def _remove_cached(self, instance_uri: str) -> None:
+        """Stops all background refreshes and deletes the connection
+        info cache from the map of caches.
+        """
+        logger.debug(
+            f"['{instance_uri}']: Removing connection info from cache"
+        )
+        # remove cache from stored caches and close it
+        cache = self._cache.pop(instance_uri)
+        await cache.close()
 
     async def __aenter__(self) -> Any:
         """Enter async context manager by returning Connector object"""

--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -212,9 +212,7 @@ class AsyncConnector:
         """Stops all background refreshes and deletes the connection
         info cache from the map of caches.
         """
-        logger.debug(
-            f"['{instance_uri}']: Removing connection info from cache"
-        )
+        logger.debug(f"['{instance_uri}']: Removing connection info from cache")
         # remove cache from stored caches and close it
         cache = self._cache.pop(instance_uri)
         await cache.close()

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -344,9 +344,7 @@ class Connector:
         """Stops all background refreshes and deletes the connection
         info cache from the map of caches.
         """
-        logger.debug(
-            f"['{instance_uri}']: Removing connection info from cache"
-        )
+        logger.debug(f"['{instance_uri}']: Removing connection info from cache")
         # remove cache from stored caches and close it
         cache = self._cache.pop(instance_uri)
         await cache.close()

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -206,8 +206,14 @@ class Connector:
         # if ip_type is str, convert to IPTypes enum
         if isinstance(ip_type, str):
             ip_type = IPTypes(ip_type.upper())
-        conn_info = await cache.connect_info()
-        ip_address = conn_info.get_preferred_ip(ip_type)
+        try:
+            conn_info = await cache.connect_info()
+            ip_address = conn_info.get_preferred_ip(ip_type)
+        except Exception:
+            # with an error from AlloyDB Admin API call or IP type, invalidate
+            # the cache and re-raise the error
+            await self._remove_cached(instance_uri)
+            raise
         logger.debug(f"['{instance_uri}']: Connecting to {ip_address}:5433")
 
         # synchronous drivers are blocking and run using executor
@@ -333,6 +339,17 @@ class Connector:
             )
 
         return sock
+
+    async def _remove_cached(self, instance_uri: str) -> None:
+        """Stops all background refreshes and deletes the connection
+        info cache from the map of caches.
+        """
+        logger.debug(
+            f"['{instance_uri}']: Removing connection info from cache"
+        )
+        # remove cache from stored caches and close it
+        cache = self._cache.pop(instance_uri)
+        await cache.close()
 
     def __enter__(self) -> "Connector":
         """Enter context manager by returning Connector object"""

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -210,8 +210,8 @@ class Connector:
             conn_info = await cache.connect_info()
             ip_address = conn_info.get_preferred_ip(ip_type)
         except Exception:
-            # with an error from AlloyDB Admin API call or IP type, invalidate
-            # the cache and re-raise the error
+            # with an error from AlloyDB API call or IP type, invalidate the
+            # cache and re-raise the error
             await self._remove_cached(instance_uri)
             raise
         logger.debug(f"['{instance_uri}']: Connecting to {ip_address}:5433")

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -208,18 +208,7 @@ class FakeAlloyDBClient:
         self._user_agent = f"test-user-agent+{driver}"
         self._credentials = FakeCredentials()
 
-        i = FakeInstance()
-        # The instances that currently exist and the client can send API requests to.
-        self.existing_instances = [
-            f"projects/{i.project}/locations/{i.region}/clusters/{i.cluster}/instances/{i.name}"
-        ]
-
     async def _get_metadata(self, *args: Any, **kwargs: Any) -> str:
-        instance_uri = f"projects/{self.instance.project}/locations/{self.instance.region}/clusters/{self.instance.cluster}/instances/{self.instance.name}"
-        if instance_uri not in self.existing_instances:
-            raise ClientResponseError(
-                RequestInfo(url=instance_uri, method="GET", headers=None), 404
-            )
         return self.instance.ip_addrs
 
     async def _get_client_certificate(
@@ -229,11 +218,6 @@ class FakeAlloyDBClient:
         cluster: str,
         pub_key: str,
     ) -> Tuple[str, List[str]]:
-        instance_uri = f"projects/{self.instance.project}/locations/{self.instance.region}/clusters/{self.instance.cluster}/instances/{self.instance.name}"
-        if instance_uri not in self.existing_instances:
-            raise ClientResponseError(
-                RequestInfo(url=instance_uri, method="POST", headers=None), 404
-            )
         root_cert, intermediate_cert, server_cert = self.instance.get_pem_certs()
         # encode public key to bytes
         pub_key_bytes: rsa.RSAPublicKey = serialization.load_pem_public_key(

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-from aiohttp import ClientResponseError, RequestInfo
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -22,6 +21,8 @@ import ssl
 import struct
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
+from aiohttp import ClientResponseError
+from aiohttp import RequestInfo
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -21,8 +21,6 @@ import ssl
 import struct
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
-from aiohttp import ClientResponseError
-from aiohttp import RequestInfo
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -210,12 +210,16 @@ class FakeAlloyDBClient:
 
         i = FakeInstance()
         # The instances that currently exist and the client can send API requests to.
-        self.existing_instances = [f"projects/{i.project}/locations/{i.region}/clusters/{i.cluster}/instances/{i.name}"]
+        self.existing_instances = [
+            f"projects/{i.project}/locations/{i.region}/clusters/{i.cluster}/instances/{i.name}"
+        ]
 
     async def _get_metadata(self, *args: Any, **kwargs: Any) -> str:
         instance_uri = f"projects/{self.instance.project}/locations/{self.instance.region}/clusters/{self.instance.cluster}/instances/{self.instance.name}"
         if instance_uri not in self.existing_instances:
-            raise ClientResponseError(RequestInfo(url = instance_uri, method = "GET", headers = None), 404)
+            raise ClientResponseError(
+                RequestInfo(url=instance_uri, method="GET", headers=None), 404
+            )
         return self.instance.ip_addrs
 
     async def _get_client_certificate(
@@ -227,7 +231,9 @@ class FakeAlloyDBClient:
     ) -> Tuple[str, List[str]]:
         instance_uri = f"projects/{self.instance.project}/locations/{self.instance.region}/clusters/{self.instance.cluster}/instances/{self.instance.name}"
         if instance_uri not in self.existing_instances:
-            raise ClientResponseError(RequestInfo(url = instance_uri, method = "POST", headers = None), 404)
+            raise ClientResponseError(
+                RequestInfo(url=instance_uri, method="POST", headers=None), 404
+            )
         root_cert, intermediate_cert, server_cert = self.instance.get_pem_certs()
         # encode public key to bytes
         pub_key_bytes: rsa.RSAPublicKey = serialization.load_pem_public_key(

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import asyncio
-from aiohttp import ClientResponseError
+from aiohttp import ClientResponseError, RequestInfo
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -214,7 +214,7 @@ class FakeAlloyDBClient:
     async def _get_metadata(self, *args: Any, **kwargs: Any) -> str:
         instance_uri = f"projects/{self.instance.project}/locations/{self.instance.region}/clusters/{self.instance.cluster}/instances/{self.instance.name}"
         if instance_uri not in self.existing_instances:
-            raise ClientResponseError(None, 404)
+            raise ClientResponseError(RequestInfo(url = instance_uri, method = "GET", headers = None), 404)
         return self.instance.ip_addrs
 
     async def _get_client_certificate(
@@ -226,7 +226,7 @@ class FakeAlloyDBClient:
     ) -> Tuple[str, List[str]]:
         instance_uri = f"projects/{self.instance.project}/locations/{self.instance.region}/clusters/{self.instance.cluster}/instances/{self.instance.name}"
         if instance_uri not in self.existing_instances:
-            raise ClientResponseError(None, 404)
+            raise ClientResponseError(RequestInfo(url = instance_uri, method = "POST", headers = None), 404)
         root_cert, intermediate_cert, server_cert = self.instance.get_pem_certs()
         # encode public key to bytes
         pub_key_bytes: rsa.RSAPublicKey = serialization.load_pem_public_key(

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -311,9 +311,6 @@ async def test_Connector_remove_cached_bad_instance(
     """
     instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
     async with AsyncConnector(credentials=credentials) as connector:
-        connector._client = AlloyDBClient("http://test-endpoint.googleapis.com", "", credentials, None, "pg8000")
-        cache = RefreshAheadCache(instance_uri, connector._client, connector._keys)
-        connector._cache[instance_uri] = cache
         with pytest.raises(ClientResponseError):
             await connector.connect(instance_uri, "asyncpg")
         assert instance_uri not in connector._cache

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -19,10 +19,13 @@ from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeConnectionInfo
 from mocks import FakeCredentials
+from mocks import FakeInstance
+from aiohttp import ClientResponseError
 import pytest
 
 from google.cloud.alloydb.connector import AsyncConnector
 from google.cloud.alloydb.connector import IPTypes
+from google.cloud.alloydb.connector.instance import RefreshAheadCache
 
 ALLOYDB_API_ENDPOINT = "https://alloydb.googleapis.com"
 
@@ -294,3 +297,47 @@ async def test_async_connect_bad_ip_type(
             exc_info.value.args[0]
             == f"Incorrect value for ip_type, got '{bad_ip_type}'. Want one of: 'PUBLIC', 'PRIVATE', 'PSC'."
         )
+
+async def test_Connector_remove_cached_bad_instance(credentials: FakeCredentials) -> None:
+    """When a Connector attempts to retrieve connection info for a
+    non-existent instance, it should delete the instance from
+    the cache and ensure no background refresh happens (which would be
+    wasted cycles).
+    """
+    instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
+    async with AsyncConnector(credentials=credentials) as connector:
+        connector._client = FakeAlloyDBClient(instance = FakeInstance(name = "bad-test-instance"))
+        cache = RefreshAheadCache(instance_uri, connector._client, connector._keys)
+        connector._cache[instance_uri] = cache
+        with pytest.raises(ClientResponseError):
+            await connector.connect(instance_uri, "asyncpg")
+        assert instance_uri not in connector._cache
+
+
+# async def test_Connector_remove_cached_no_ip_type(
+#     fake_credentials: Credentials, fake_client: CloudSQLClient
+# ) -> None:
+#     """When a Connector attempts to connect and preferred IP type is not present,
+#     it should delete the instance from the cache and ensure no background refresh
+#     happens (which would be wasted cycles).
+#     """
+#     # set instance to only have public IP
+#     fake_client.instance.ip_addrs = {"PRIMARY": "127.0.0.1"}
+#     async with Connector(
+#         credentials=fake_credentials, loop=asyncio.get_running_loop()
+#     ) as connector:
+#         conn_name = "test-project:test-region:test-instance"
+#         # populate cache
+#         cache = RefreshAheadCache(conn_name, fake_client, connector._keys)
+#         connector._cache[(conn_name, False)] = cache
+#         # test instance does not have Private IP, thus should invalidate cache
+#         with pytest.raises(CloudSQLIPTypeError):
+#             await connector.connect_async(
+#                 conn_name,
+#                 "pg8000",
+#                 user="my-user",
+#                 password="my-pass",
+#                 ip_type="private",
+#             )
+#         # check that cache has been removed from dict
+#         assert (conn_name, False) not in connector._cache

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -299,7 +299,10 @@ async def test_async_connect_bad_ip_type(
             == f"Incorrect value for ip_type, got '{bad_ip_type}'. Want one of: 'PUBLIC', 'PRIVATE', 'PSC'."
         )
 
-async def test_Connector_remove_cached_bad_instance(credentials: FakeCredentials) -> None:
+
+async def test_Connector_remove_cached_bad_instance(
+    credentials: FakeCredentials,
+) -> None:
     """When a Connector attempts to retrieve connection info for a
     non-existent instance, it should delete the instance from
     the cache and ensure no background refresh happens (which would be
@@ -307,7 +310,9 @@ async def test_Connector_remove_cached_bad_instance(credentials: FakeCredentials
     """
     instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
     async with AsyncConnector(credentials=credentials) as connector:
-        connector._client = FakeAlloyDBClient(instance = FakeInstance(name = "bad-test-instance"))
+        connector._client = FakeAlloyDBClient(
+            instance=FakeInstance(name="bad-test-instance")
+        )
         cache = RefreshAheadCache(instance_uri, connector._client, connector._keys)
         connector._cache[instance_uri] = cache
         with pytest.raises(ClientResponseError):

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -23,6 +23,7 @@ from mocks import FakeCredentials
 from mocks import FakeInstance
 import pytest
 
+from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector import AsyncConnector
 from google.cloud.alloydb.connector import IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
@@ -310,9 +311,7 @@ async def test_Connector_remove_cached_bad_instance(
     """
     instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
     async with AsyncConnector(credentials=credentials) as connector:
-        connector._client = FakeAlloyDBClient(
-            instance=FakeInstance(name="bad-test-instance")
-        )
+        connector._client = AlloyDBClient("http://test-endpoint.googleapis.com", "", credentials, None, "pg8000")
         cache = RefreshAheadCache(instance_uri, connector._client, connector._keys)
         connector._cache[instance_uri] = cache
         with pytest.raises(ClientResponseError):

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -20,12 +20,10 @@ from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeConnectionInfo
 from mocks import FakeCredentials
-from mocks import FakeInstance
 import pytest
 
 from google.cloud.alloydb.connector import AsyncConnector
 from google.cloud.alloydb.connector import IPTypes
-from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -15,18 +15,18 @@
 import asyncio
 from typing import Union
 
+from aiohttp import ClientResponseError
 from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeConnectionInfo
 from mocks import FakeCredentials
 from mocks import FakeInstance
-from aiohttp import ClientResponseError
 import pytest
 
 from google.cloud.alloydb.connector import AsyncConnector
 from google.cloud.alloydb.connector import IPTypes
-from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
+from google.cloud.alloydb.connector.instance import RefreshAheadCache
 
 ALLOYDB_API_ENDPOINT = "https://alloydb.googleapis.com"
 

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -23,9 +23,9 @@ from mocks import FakeCredentials
 from mocks import FakeInstance
 import pytest
 
-from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector import AsyncConnector
 from google.cloud.alloydb.connector import IPTypes
+from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -26,6 +26,7 @@ import pytest
 from google.cloud.alloydb.connector import AsyncConnector
 from google.cloud.alloydb.connector import IPTypes
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
+from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 
 ALLOYDB_API_ENDPOINT = "https://alloydb.googleapis.com"
 
@@ -314,30 +315,22 @@ async def test_Connector_remove_cached_bad_instance(credentials: FakeCredentials
         assert instance_uri not in connector._cache
 
 
-# async def test_Connector_remove_cached_no_ip_type(
-#     fake_credentials: Credentials, fake_client: CloudSQLClient
-# ) -> None:
-#     """When a Connector attempts to connect and preferred IP type is not present,
-#     it should delete the instance from the cache and ensure no background refresh
-#     happens (which would be wasted cycles).
-#     """
-#     # set instance to only have public IP
-#     fake_client.instance.ip_addrs = {"PRIMARY": "127.0.0.1"}
-#     async with Connector(
-#         credentials=fake_credentials, loop=asyncio.get_running_loop()
-#     ) as connector:
-#         conn_name = "test-project:test-region:test-instance"
-#         # populate cache
-#         cache = RefreshAheadCache(conn_name, fake_client, connector._keys)
-#         connector._cache[(conn_name, False)] = cache
-#         # test instance does not have Private IP, thus should invalidate cache
-#         with pytest.raises(CloudSQLIPTypeError):
-#             await connector.connect_async(
-#                 conn_name,
-#                 "pg8000",
-#                 user="my-user",
-#                 password="my-pass",
-#                 ip_type="private",
-#             )
-#         # check that cache has been removed from dict
-#         assert (conn_name, False) not in connector._cache
+async def test_Connector_remove_cached_no_ip_type(credentials: FakeCredentials) -> None:
+    """When a Connector attempts to connect and preferred IP type is not present,
+    it should delete the instance from the cache and ensure no background refresh
+    happens (which would be wasted cycles).
+    """
+    instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/test-instance"
+    # set instance to only have Public IP
+    fake_client = FakeAlloyDBClient()
+    fake_client.instance.ip_addrs = {"PUBLIC": "127.0.0.1"}
+    async with AsyncConnector(credentials=credentials) as connector:
+        connector._client = fake_client
+        # populate cache
+        cache = RefreshAheadCache(instance_uri, fake_client, connector._keys)
+        connector._cache[instance_uri] = cache
+        # test instance does not have Private IP, thus should invalidate cache
+        with pytest.raises(IPTypeNotFoundError):
+            await connector.connect(instance_uri, "asyncpg", ip_type="private")
+        # check that cache has been removed from dict
+        assert instance_uri not in connector._cache

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -211,7 +211,9 @@ def test_Connector_close_called_multiple_times(credentials: FakeCredentials) -> 
     connector.close()
 
 
-async def test_Connector_remove_cached_bad_instance(credentials: FakeCredentials) -> None:
+async def test_Connector_remove_cached_bad_instance(
+    credentials: FakeCredentials,
+) -> None:
     """When a Connector attempts to retrieve connection info for a
     non-existent instance, it should delete the instance from
     the cache and ensure no background refresh happens (which would be

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -210,7 +210,9 @@ def test_Connector_close_called_multiple_times(credentials: FakeCredentials) -> 
     connector.close()
 
 
-async def test_Connector_remove_cached_bad_instance(credentials: FakeCredentials) -> None:
+async def test_Connector_remove_cached_bad_instance(
+    credentials: FakeCredentials,
+) -> None:
     """When a Connector attempts to retrieve connection info for a
     non-existent instance, it should delete the instance from
     the cache and ensure no background refresh happens (which would be
@@ -218,7 +220,9 @@ async def test_Connector_remove_cached_bad_instance(credentials: FakeCredentials
     """
     instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
     with Connector(credentials) as connector:
-        connector._client = FakeAlloyDBClient(instance = FakeInstance(name = "bad-test-instance"))
+        connector._client = FakeAlloyDBClient(
+            instance=FakeInstance(name="bad-test-instance")
+        )
         cache = RefreshAheadCache(instance_uri, connector._client, connector._keys)
         connector._cache[instance_uri] = cache
         with pytest.raises(ClientResponseError):

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -16,11 +16,11 @@ import asyncio
 from threading import Thread
 from typing import Union
 
+from aiohttp import ClientResponseError
 from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeCredentials
 from mocks import FakeInstance
-from aiohttp import ClientResponseError
 import pytest
 
 from google.cloud.alloydb.connector import Connector

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -219,13 +219,10 @@ async def test_Connector_remove_cached_bad_instance(credentials: FakeCredentials
     """
     instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
     with Connector(credentials) as connector:
-        connector._client = AlloyDBClient("http://test-endpoint.googleapis.com", "", credentials, None, "pg8000")
         connector._keys = asyncio.wrap_future(
             asyncio.run_coroutine_threadsafe(generate_keys(), asyncio.get_event_loop()),
             loop=asyncio.get_event_loop(),
         )
-        cache = RefreshAheadCache(instance_uri, connector._client, connector._keys)
-        connector._cache[instance_uri] = cache
         with pytest.raises(ClientResponseError):
             await connector.connect_async(instance_uri, "pg8000")
         assert instance_uri not in connector._cache

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -20,12 +20,10 @@ from aiohttp import ClientResponseError
 from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeCredentials
-from mocks import FakeInstance
 import pytest
 
 from google.cloud.alloydb.connector import Connector
 from google.cloud.alloydb.connector import IPTypes
-from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.utils import generate_keys

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -220,8 +220,8 @@ async def test_Connector_remove_cached_bad_instance(
     instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
     with Connector(credentials) as connector:
         connector._keys = asyncio.wrap_future(
-            asyncio.run_coroutine_threadsafe(generate_keys(), asyncio.get_event_loop()),
-            loop=asyncio.get_event_loop(),
+            asyncio.run_coroutine_threadsafe(generate_keys(), asyncio.get_running_loop()),
+            loop=asyncio.get_running_loop(),
         )
         with pytest.raises(ClientResponseError):
             await connector.connect_async(instance_uri, "pg8000")
@@ -240,8 +240,8 @@ async def test_Connector_remove_cached_no_ip_type(credentials: FakeCredentials) 
     with Connector(credentials=credentials) as connector:
         connector._client = fake_client
         connector._keys = asyncio.wrap_future(
-            asyncio.run_coroutine_threadsafe(generate_keys(), asyncio.get_event_loop()),
-            loop=asyncio.get_event_loop(),
+            asyncio.run_coroutine_threadsafe(generate_keys(), asyncio.get_running_loop()),
+            loop=asyncio.get_running_loop(),
         )
         cache = RefreshAheadCache(instance_uri, fake_client, connector._keys)
         connector._cache[instance_uri] = cache

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -220,7 +220,9 @@ async def test_Connector_remove_cached_bad_instance(
     instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
     with Connector(credentials) as connector:
         connector._keys = asyncio.wrap_future(
-            asyncio.run_coroutine_threadsafe(generate_keys(), asyncio.get_running_loop()),
+            asyncio.run_coroutine_threadsafe(
+                generate_keys(), asyncio.get_running_loop()
+            ),
             loop=asyncio.get_running_loop(),
         )
         with pytest.raises(ClientResponseError):
@@ -240,7 +242,9 @@ async def test_Connector_remove_cached_no_ip_type(credentials: FakeCredentials) 
     with Connector(credentials=credentials) as connector:
         connector._client = fake_client
         connector._keys = asyncio.wrap_future(
-            asyncio.run_coroutine_threadsafe(generate_keys(), asyncio.get_running_loop()),
+            asyncio.run_coroutine_threadsafe(
+                generate_keys(), asyncio.get_running_loop()
+            ),
             loop=asyncio.get_running_loop(),
         )
         cache = RefreshAheadCache(instance_uri, fake_client, connector._keys)

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -23,9 +23,9 @@ from mocks import FakeCredentials
 from mocks import FakeInstance
 import pytest
 
-from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector import Connector
 from google.cloud.alloydb.connector import IPTypes
+from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.utils import generate_keys


### PR DESCRIPTION
This change is analogous to CloudSQL's https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/pull/1118.

The `Connector` caches connection info for future connections and schedules refresh operations. For unrecoverable errors, the cache should be invalidated to stop future bad refreshes. The cache should also be invalidated on failed IP lookups. This PR does these things.