### PR TITLE
feat: improve aiohttp client error messages

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,4 @@ pytest-asyncio==0.24.0
 pytest-cov==6.0.0
 pytest-aiohttp==1.0.5
 SQLAlchemy[asyncio]==2.0.36
+aioresponses==0.7.7

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -170,10 +170,9 @@ async def test__get_metadata_error(
             await client._get_metadata(
                 "my-project", "my-region", "my-cluster", "my-instance"
             )
-        exc = exc_info.value
-        assert exc.status == 403
+        assert exc_info.value.status == 403
         assert (
-            exc.message
+            exc_info.value.message
             == "AlloyDB API has not been used in project 123456789 before or it is disabled"
         )
     await client.close()
@@ -205,10 +204,9 @@ async def test__get_metadata_error_parsing_json(
             await client._get_metadata(
                 "my-project", "my-region", "my-cluster", "my-instance"
             )
-        exc = exc_info.value
-        assert exc.status == 403
+        assert exc_info.value.status == 403
         assert (
-            exc.message
+            exc_info.value.message
             != "AlloyDB API has not been used in project 123456789 before or it is disabled"
         )
     await client.close()
@@ -263,9 +261,8 @@ async def test__get_client_certificate_error(
             await client._get_client_certificate(
                 "my-project", "my-region", "my-cluster", ""
             )
-        exc = exc_info.value
-        assert exc.status == 404
-        assert exc.message == "The AlloyDB instance does not exist."
+        assert exc_info.value.status == 404
+        assert exc_info.value.message == "The AlloyDB instance does not exist."
     await client.close()
 
 
@@ -295,9 +292,8 @@ async def test__get_client_certificate_error_parsing_json(
             await client._get_client_certificate(
                 "my-project", "my-region", "my-cluster", ""
             )
-        exc = exc_info.value
-        assert exc.status == 404
-        assert exc.message != "The AlloyDB instance does not exist."
+        assert exc_info.value.status == 404
+        assert exc_info.value.message != "The AlloyDB instance does not exist."
     await client.close()
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -182,8 +182,8 @@ async def test__get_metadata_error_parsing_json(
     credentials: FakeCredentials,
 ) -> None:
     """
-    Test that AlloyDB API error messages are raised for _get_metadata when
-    response JSON fails to be parsed.
+    Test that aiohttp default error messages are raised when _get_metadata gets
+    a bad JSON response.
     """
     # mock AlloyDB API calls with exceptions
     client = AlloyDBClient(
@@ -205,10 +205,7 @@ async def test__get_metadata_error_parsing_json(
                 "my-project", "my-region", "my-cluster", "my-instance"
             )
         assert exc_info.value.status == 403
-        assert (
-            exc_info.value.message
-            != "AlloyDB API has not been used in project 123456789 before or it is disabled"
-        )
+        assert exc_info.value.message == "Forbidden"
     await client.close()
 
 
@@ -270,8 +267,8 @@ async def test__get_client_certificate_error_parsing_json(
     credentials: FakeCredentials,
 ) -> None:
     """
-    Test that AlloyDB API error messages are raised for _get_client_certificate
-    when response JSON fails to be parsed.
+    Test that aiohttp default error messages are raised when
+    _get_client_certificate gets a bad JSON response.
     """
     # mock AlloyDB API calls with exceptions
     client = AlloyDBClient(
@@ -293,7 +290,7 @@ async def test__get_client_certificate_error_parsing_json(
                 "my-project", "my-region", "my-cluster", ""
             )
         assert exc_info.value.status == 404
-        assert exc_info.value.message != "The AlloyDB instance does not exist."
+        assert exc_info.value.message == "Not Found"
     await client.close()
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -15,7 +15,8 @@
 import json
 from typing import Any, Optional
 
-from aiohttp import ClientResponseError, web
+from aiohttp import ClientResponseError
+from aiohttp import web
 from aioresponses import aioresponses
 from mocks import FakeCredentials
 import pytest
@@ -166,7 +167,9 @@ async def test__get_metadata_error(
             repeat=True,
         )
         with pytest.raises(ClientResponseError) as exc_info:
-            await client._get_metadata("my-project", "my-region", "my-cluster", "my-instance")
+            await client._get_metadata(
+                "my-project", "my-region", "my-cluster", "my-instance"
+            )
         exc = exc_info.value
         assert exc.status == 403
         assert (
@@ -190,7 +193,7 @@ async def test__get_metadata_error_parsing_json(
         credentials=credentials,
     )
     get_url = "https://alloydb.googleapis.com/v1beta/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance/connectionInfo"
-    resp_body = ["error"] # invalid json
+    resp_body = ["error"]  # invalid json
     with aioresponses() as mocked:
         mocked.get(
             get_url,
@@ -199,7 +202,9 @@ async def test__get_metadata_error_parsing_json(
             repeat=True,
         )
         with pytest.raises(ClientResponseError) as exc_info:
-            await client._get_metadata("my-project", "my-region", "my-cluster", "my-instance")
+            await client._get_metadata(
+                "my-project", "my-region", "my-cluster", "my-instance"
+            )
         exc = exc_info.value
         assert exc.status == 403
         assert (
@@ -255,7 +260,9 @@ async def test__get_client_certificate_error(
             repeat=True,
         )
         with pytest.raises(ClientResponseError) as exc_info:
-            await client._get_client_certificate("my-project", "my-region", "my-cluster", "")
+            await client._get_client_certificate(
+                "my-project", "my-region", "my-cluster", ""
+            )
         exc = exc_info.value
         assert exc.status == 404
         assert exc.message == "The AlloyDB instance does not exist."
@@ -276,7 +283,7 @@ async def test__get_client_certificate_error_parsing_json(
         credentials=credentials,
     )
     post_url = "https://alloydb.googleapis.com/v1beta/projects/my-project/locations/my-region/clusters/my-cluster:generateClientCertificate"
-    resp_body = ["error"] # invalid json
+    resp_body = ["error"]  # invalid json
     with aioresponses() as mocked:
         mocked.post(
             post_url,
@@ -285,7 +292,9 @@ async def test__get_client_certificate_error_parsing_json(
             repeat=True,
         )
         with pytest.raises(ClientResponseError) as exc_info:
-            await client._get_client_certificate("my-project", "my-region", "my-cluster", "")
+            await client._get_client_certificate(
+                "my-project", "my-region", "my-cluster", ""
+            )
         exc = exc_info.value
         assert exc.status == 404
         assert exc.message != "The AlloyDB instance does not exist."


### PR DESCRIPTION
This change is similar to https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/pull/1201, except for AlloyDB.

In short, we want to use the AlloyDB API's response body for error messages, because they are more detailed.