### PR TITLE
chore: support static connection info

### DIFF
--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -21,12 +21,13 @@ from types import TracebackType
 from typing import Any, Optional, TYPE_CHECKING, Union
 
 import google.auth
-import google.auth.transport.requests
 from google.auth.credentials import with_scopes_if_required
+import google.auth.transport.requests
 
 import google.cloud.alloydb.connector.asyncpg as asyncpg
 from google.cloud.alloydb.connector.client import AlloyDBClient
-from google.cloud.alloydb.connector.enums import IPTypes, RefreshStrategy
+from google.cloud.alloydb.connector.enums import IPTypes
+from google.cloud.alloydb.connector.enums import RefreshStrategy
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.lazy import LazyRefreshCache
 from google.cloud.alloydb.connector.static import StaticConnectionInfoCache

--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -21,13 +21,12 @@ from types import TracebackType
 from typing import Any, Optional, TYPE_CHECKING, Union
 
 import google.auth
-from google.auth.credentials import with_scopes_if_required
 import google.auth.transport.requests
+from google.auth.credentials import with_scopes_if_required
 
 import google.cloud.alloydb.connector.asyncpg as asyncpg
 from google.cloud.alloydb.connector.client import AlloyDBClient
-from google.cloud.alloydb.connector.enums import IPTypes
-from google.cloud.alloydb.connector.enums import RefreshStrategy
+from google.cloud.alloydb.connector.enums import IPTypes, RefreshStrategy
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.lazy import LazyRefreshCache
 from google.cloud.alloydb.connector.static import StaticConnectionInfoCache
@@ -145,13 +144,12 @@ class AsyncConnector:
             )
 
         enable_iam_auth = kwargs.pop("enable_iam_auth", self._enable_iam_auth)
-        static_conn_info = kwargs.pop("static_conn_info", self._static_conn_info)
 
         # use existing connection info if possible
         if instance_uri in self._cache:
             cache = self._cache[instance_uri]
-        elif static_conn_info:
-            cache = StaticConnectionInfoCache(instance_uri, static_conn_info)
+        elif self._static_conn_info:
+            cache = StaticConnectionInfoCache(instance_uri, self._static_conn_info)
         else:
             if self._refresh_strategy == RefreshStrategy.LAZY:
                 logger.debug(

--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -75,7 +75,7 @@ class AsyncConnector:
         ip_type: str | IPTypes = IPTypes.PRIVATE,
         user_agent: Optional[str] = None,
         refresh_strategy: str | RefreshStrategy = RefreshStrategy.BACKGROUND,
-        static_conn_info: io.TextIOBase = None,
+        static_conn_info: Optional[io.TextIOBase] = None,
     ) -> None:
         self._cache: dict[str, Union[RefreshAheadCache, LazyRefreshCache]] = {}
         # initialize default params
@@ -147,6 +147,7 @@ class AsyncConnector:
         enable_iam_auth = kwargs.pop("enable_iam_auth", self._enable_iam_auth)
 
         # use existing connection info if possible
+        cache: Union[RefreshAheadCache, LazyRefreshCache, StaticConnectionInfoCache]
         if instance_uri in self._cache:
             cache = self._cache[instance_uri]
         elif self._static_conn_info:

--- a/google/cloud/alloydb/connector/connection_info.py
+++ b/google/cloud/alloydb/connector/connection_info.py
@@ -27,7 +27,7 @@ from google.cloud.alloydb.connector.utils import _write_to_file
 if TYPE_CHECKING:
     import datetime
 
-    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
 
     from google.cloud.alloydb.connector.enums import IPTypes
 
@@ -41,7 +41,7 @@ class ConnectionInfo:
 
     cert_chain: list[str]
     ca_cert: str
-    key: rsa.RSAPrivateKey
+    key: PrivateKeyTypes
     ip_addrs: dict[str, Optional[str]]
     expiration: datetime.datetime
     context: Optional[ssl.SSLContext] = None

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -87,7 +87,7 @@ class Connector:
         ip_type: str | IPTypes = IPTypes.PRIVATE,
         user_agent: Optional[str] = None,
         refresh_strategy: str | RefreshStrategy = RefreshStrategy.BACKGROUND,
-        static_conn_info: io.TextIOBase = None,
+        static_conn_info: Optional[io.TextIOBase] = None,
     ) -> None:
         # create event loop and start it in background thread
         self._loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
@@ -176,6 +176,7 @@ class Connector:
             )
         enable_iam_auth = kwargs.pop("enable_iam_auth", self._enable_iam_auth)
         # use existing connection info if possible
+        cache: Union[RefreshAheadCache, LazyRefreshCache, StaticConnectionInfoCache]
         if instance_uri in self._cache:
             cache = self._cache[instance_uri]
         elif self._static_conn_info:

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -76,6 +76,9 @@ class Connector:
         static_conn_info (io.TextIOBase): A file-like JSON object that contains
             static connection info for the StaticConnectionInfoCache.
             Defaults to None, which will not use the StaticConnectionInfoCache.
+            This is a *dev-only* option and should not be used in production as
+            it will result in failed connections after the client certificate
+            expires.
     """
 
     def __init__(

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -15,27 +15,29 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 import io
 import logging
 import socket
 import struct
-from functools import partial
 from threading import Thread
 from types import TracebackType
 from typing import Any, Optional, TYPE_CHECKING, Union
 
 from google.auth import default
-from google.auth.credentials import TokenState, with_scopes_if_required
+from google.auth.credentials import TokenState
+from google.auth.credentials import with_scopes_if_required
 from google.auth.transport import requests
 
-import google.cloud.alloydb.connector.pg8000 as pg8000
-import google.cloud.alloydb_connectors_v1.proto.resources_pb2 as connectorspb
 from google.cloud.alloydb.connector.client import AlloyDBClient
-from google.cloud.alloydb.connector.enums import IPTypes, RefreshStrategy
+from google.cloud.alloydb.connector.enums import IPTypes
+from google.cloud.alloydb.connector.enums import RefreshStrategy
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.lazy import LazyRefreshCache
+import google.cloud.alloydb.connector.pg8000 as pg8000
 from google.cloud.alloydb.connector.static import StaticConnectionInfoCache
 from google.cloud.alloydb.connector.utils import generate_keys
+import google.cloud.alloydb_connectors_v1.proto.resources_pb2 as connectorspb
 
 if TYPE_CHECKING:
     import ssl

--- a/google/cloud/alloydb/connector/static.py
+++ b/google/cloud/alloydb/connector/static.py
@@ -26,7 +26,12 @@ from google.cloud.alloydb.connector.connection_info import ConnectionInfo
 class StaticConnectionInfoCache:
     """
     StaticConnectionInfoCache creates a connection info cache that will always
-    return a pre-defined connection info.
+    return a pre-defined connection info. This is a *dev-only* option and
+    should not be used in production as it will result in failed connections
+    after the client certificate expires. It is also subject to breaking changes
+    in the format. NOTE: The static connection info is not refreshed by the
+    connector. The JSON format supports multiple instances, regardless of
+    cluster.
 
     This static connection info should hold JSON with the following format:
         {

--- a/google/cloud/alloydb/connector/static.py
+++ b/google/cloud/alloydb/connector/static.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
 import io
 import json
+from datetime import datetime, timedelta, timezone
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from google.cloud.alloydb.connector.connection_info import ConnectionInfo
 

--- a/google/cloud/alloydb/connector/static.py
+++ b/google/cloud/alloydb/connector/static.py
@@ -58,7 +58,9 @@ class StaticConnectionInfoCache:
         cert_chain = static_info[instance_uri]["pemCertificateChain"]
         dns = ""
         if static_info[instance_uri]["pscInstanceConfig"]:
-            dns = static_info[instance_uri]["pscInstanceConfig"]["pscDnsName"].rstrip(".")
+            dns = static_info[instance_uri]["pscInstanceConfig"]["pscDnsName"].rstrip(
+                "."
+            )
         ip_addrs = {
             "PRIVATE": static_info[instance_uri]["ipAddress"],
             "PUBLIC": static_info[instance_uri]["publicIpAddress"],
@@ -67,9 +69,12 @@ class StaticConnectionInfoCache:
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
         priv_key = static_info["privateKey"]
         priv_key_bytes: rsa.RSAPrivateKey = serialization.load_pem_private_key(
-            priv_key.encode("UTF-8"), password=None,
+            priv_key.encode("UTF-8"),
+            password=None,
         )
-        self._info = ConnectionInfo(cert_chain, ca_cert, priv_key_bytes, ip_addrs, expiration)
+        self._info = ConnectionInfo(
+            cert_chain, ca_cert, priv_key_bytes, ip_addrs, expiration
+        )
 
     async def force_refresh(self) -> None:
         """
@@ -84,7 +89,7 @@ class StaticConnectionInfoCache:
         connection to the AlloyDB instance.
         """
         return self._info
-    
+
     async def close(self) -> None:
         """
         This is a no-op.

--- a/google/cloud/alloydb/connector/static.py
+++ b/google/cloud/alloydb/connector/static.py
@@ -1,0 +1,90 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import io
+import json
+
+from google.cloud.alloydb.connector.connection_info import ConnectionInfo
+
+
+class StaticConnectionInfoCache:
+    """
+    StaticConnectionInfoCache creates a connection info cache that will always
+    return a pre-defined connection info.
+
+    This static connection info should hold JSON with the following format:
+        {
+            "publicKey": "<PEM Encoded public RSA key>",
+            "privateKey": "<PEM Encoded private RSA key>",
+            "projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE>": {
+                "ipAddress": "<PSA-based private IP address>",
+                "publicIpAddress": "<public IP address>",
+                "pscInstanceConfig": {
+                    "pscDnsName": "<PSC DNS name>"
+                },
+                "pemCertificateChain": [
+                    "<client cert>", "<intermediate cert>", "<CA cert>"
+                ],
+                "caCert": "<CA cert>"
+            }
+        }
+    """
+
+    def __init__(self, instance_uri: str, static_conn_info: io.TextIOBase) -> None:
+        """
+        Initializes a StaticConnectionInfoCache instance.
+
+        Args:
+            instance_uri (str): The AlloyDB instance's connection URI.
+            static_conn_info (io.TextIOBase): The static connection info JSON.
+        """
+        static_info = json.load(static_conn_info)
+        ca_cert = static_info[instance_uri]["caCert"]
+        cert_chain = static_info[instance_uri]["pemCertificateChain"]
+        ip_addrs = {
+            "PRIVATE": static_info[instance_uri]["ipAddress"],
+            "PUBLIC": static_info[instance_uri]["publicIpAddress"],
+            "PSC": static_info[instance_uri]["pscInstanceConfig"]["pscDnsName"],
+        }
+        expiration = datetime.now(timezone.utc) + timedelta(hours=1)
+        priv_key = static_info["privateKey"]
+        priv_key_bytes: rsa.RSAPrivateKey = serialization.load_pem_private_key(
+            priv_key.encode("UTF-8"), password=None,
+        )
+        self._info = ConnectionInfo(cert_chain, ca_cert, priv_key_bytes, ip_addrs, expiration)
+
+    async def force_refresh(self) -> None:
+        """
+        This is a no-op as the cache holds only static connection information
+        and does no refresh.
+        """
+        pass
+
+    async def connect_info(self) -> ConnectionInfo:
+        """
+        Retrieves ConnectionInfo instance for establishing a secure
+        connection to the AlloyDB instance.
+        """
+        return self._info
+    
+    async def close(self) -> None:
+        """
+        This is a no-op.
+        """
+        pass

--- a/google/cloud/alloydb/connector/static.py
+++ b/google/cloud/alloydb/connector/static.py
@@ -19,7 +19,6 @@ import io
 import json
 
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 
 from google.cloud.alloydb.connector.connection_info import ConnectionInfo
 
@@ -70,9 +69,8 @@ class StaticConnectionInfoCache:
         }
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
         priv_key = static_info["privateKey"]
-        priv_key_bytes: rsa.RSAPrivateKey = serialization.load_pem_private_key(
-            priv_key.encode("UTF-8"),
-            password=None,
+        priv_key_bytes = serialization.load_pem_private_key(
+            priv_key.encode("UTF-8"), password=None
         )
         self._info = ConnectionInfo(
             cert_chain, ca_cert, priv_key_bytes, ip_addrs, expiration

--- a/google/cloud/alloydb/connector/static.py
+++ b/google/cloud/alloydb/connector/static.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 import io
 import json
-from datetime import datetime, timedelta, timezone
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/google/cloud/alloydb/connector/static.py
+++ b/google/cloud/alloydb/connector/static.py
@@ -57,10 +57,13 @@ class StaticConnectionInfoCache:
         static_info = json.load(static_conn_info)
         ca_cert = static_info[instance_uri]["caCert"]
         cert_chain = static_info[instance_uri]["pemCertificateChain"]
+        dns = ""
+        if static_info[instance_uri]["pscInstanceConfig"]:
+            dns = static_info[instance_uri]["pscInstanceConfig"]["pscDnsName"].rstrip(".")
         ip_addrs = {
             "PRIVATE": static_info[instance_uri]["ipAddress"],
             "PUBLIC": static_info[instance_uri]["publicIpAddress"],
-            "PSC": static_info[instance_uri]["pscInstanceConfig"]["pscDnsName"],
+            "PSC": dns,
         }
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
         priv_key = static_info["privateKey"]

--- a/google/cloud/alloydb/connector/types.py
+++ b/google/cloud/alloydb/connector/types.py
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing
+
+from google.cloud.alloydb.connector.instance import RefreshAheadCache
+from google.cloud.alloydb.connector.lazy import LazyRefreshCache
+from google.cloud.alloydb.connector.static import StaticConnectionInfoCache
+
+CacheTypes = typing.Union[
+    RefreshAheadCache, LazyRefreshCache, StaticConnectionInfoCache
+]

--- a/google/cloud/alloydb/connector/utils.py
+++ b/google/cloud/alloydb/connector/utils.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 import aiofiles
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
 
 
 async def _write_to_file(
-    dir_path: str, ca_cert: str, cert_chain: list[str], key: rsa.RSAPrivateKey
+    dir_path: str, ca_cert: str, cert_chain: list[str], key: PrivateKeyTypes
 ) -> tuple[str, str, str]:
     """
     Helper function to write the server_ca, client certificate and

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,7 +16,6 @@ import asyncio
 import socket
 import ssl
 from threading import Thread
-from typing import Generator
 
 from aiofiles.tempfile import TemporaryDirectory
 from mocks import FakeAlloyDBClient

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -66,8 +66,8 @@ async def start_proxy_server(instance: FakeInstance) -> None:
         # listen for incoming connections
         sock.listen(5)
 
-        while True:
-            with context.wrap_socket(sock, server_side=True) as ssock:
+        with context.wrap_socket(sock, server_side=True) as ssock:
+            while True:
                 conn, _ = ssock.accept()
                 metadata_exchange(conn)
                 conn.sendall(instance.name.encode("utf-8"))
@@ -75,7 +75,7 @@ async def start_proxy_server(instance: FakeInstance) -> None:
 
 
 @pytest.fixture(scope="session")
-def proxy_server(fake_instance: FakeInstance) -> Generator:
+def proxy_server(fake_instance: FakeInstance) -> None:
     """Run local proxy server capable of performing metadata exchange"""
     thread = Thread(
         target=asyncio.run,
@@ -87,5 +87,4 @@ def proxy_server(fake_instance: FakeInstance) -> Generator:
         daemon=True,
     )
     thread.start()
-    yield thread
-    thread.join()
+    thread.join(0.1) # wait 100ms to allow the proxy server to start

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,8 +20,7 @@ from typing import Generator
 
 import pytest
 from aiofiles.tempfile import TemporaryDirectory
-from mocks import (FakeAlloyDBClient, FakeCredentials, FakeInstance,
-                   metadata_exchange)
+from mocks import FakeAlloyDBClient, FakeCredentials, FakeInstance, metadata_exchange
 
 from google.cloud.alloydb.connector.utils import _write_to_file
 
@@ -85,4 +84,4 @@ def proxy_server(fake_instance: FakeInstance) -> None:
         daemon=True,
     )
     thread.start()
-    thread.join(0.1) # wait 100ms to allow the proxy server to start
+    thread.join(0.1)  # wait 100ms to allow the proxy server to start

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,11 +19,11 @@ from threading import Thread
 from typing import Generator
 
 from aiofiles.tempfile import TemporaryDirectory
-import pytest
 from mocks import FakeAlloyDBClient
 from mocks import FakeCredentials
 from mocks import FakeInstance
 from mocks import metadata_exchange
+import pytest
 
 from google.cloud.alloydb.connector.utils import _write_to_file
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,9 +18,12 @@ import ssl
 from threading import Thread
 from typing import Generator
 
-import pytest
 from aiofiles.tempfile import TemporaryDirectory
-from mocks import FakeAlloyDBClient, FakeCredentials, FakeInstance, metadata_exchange
+import pytest
+from mocks import FakeAlloyDBClient
+from mocks import FakeCredentials
+from mocks import FakeInstance
+from mocks import metadata_exchange
 
 from google.cloud.alloydb.connector.utils import _write_to_file
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,6 +16,7 @@ import asyncio
 import socket
 import ssl
 from threading import Thread
+from typing import Final
 
 from aiofiles.tempfile import TemporaryDirectory
 from mocks import FakeAlloyDBClient
@@ -25,6 +26,8 @@ from mocks import metadata_exchange
 import pytest
 
 from google.cloud.alloydb.connector.utils import _write_to_file
+
+DELAY: Final[float] = 1.0
 
 
 @pytest.fixture
@@ -86,4 +89,4 @@ def proxy_server(fake_instance: FakeInstance) -> None:
         daemon=True,
     )
     thread.start()
-    thread.join(0.1)  # wait 100ms to allow the proxy server to start
+    thread.join(DELAY)  # add a delay to allow the proxy server to start

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,7 +16,6 @@ import asyncio
 import socket
 import ssl
 from threading import Thread
-from typing import Final
 
 from aiofiles.tempfile import TemporaryDirectory
 from mocks import FakeAlloyDBClient
@@ -27,7 +26,7 @@ import pytest
 
 from google.cloud.alloydb.connector.utils import _write_to_file
 
-DELAY: Final[float] = 1.0
+DELAY = 1.0
 
 
 @pytest.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,12 +18,10 @@ import ssl
 from threading import Thread
 from typing import Generator
 
-from aiofiles.tempfile import TemporaryDirectory
-from mocks import FakeAlloyDBClient
-from mocks import FakeCredentials
-from mocks import FakeInstance
-from mocks import metadata_exchange
 import pytest
+from aiofiles.tempfile import TemporaryDirectory
+from mocks import (FakeAlloyDBClient, FakeCredentials, FakeInstance,
+                   metadata_exchange)
 
 from google.cloud.alloydb.connector.utils import _write_to_file
 

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -191,7 +191,7 @@ class FakeInstance:
             encoding=serialization.Encoding.PEM
         ).decode("UTF-8")
         return (pem_root, pem_intermediate, pem_server)
-    
+
     def generate_pem_certificate_chain(self, pub_key: str) -> tuple[str, list[str]]:
         """Generate the CA certificate and certificate chain for the AlloyDB instance."""
         root_cert, intermediate_cert, server_cert = self.get_pem_certs()
@@ -215,7 +215,7 @@ class FakeInstance:
             encoding=serialization.Encoding.PEM
         ).decode("UTF-8")
         return (server_cert, [client_cert, intermediate_cert, root_cert])
-    
+
     def uri(self) -> str:
         """The URI of the AlloyDB instance."""
         return f"projects/{self.project}/locations/{self.region}/clusters/{self.cluster}/instances/{self.name}"
@@ -426,14 +426,11 @@ def write_static_info(i: FakeInstance) -> io.StringIO:
         )
         .decode("UTF-8")
     )
-    priv_pem = (
-        priv_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-        .decode("UTF-8")
-    )
+    priv_pem = priv_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("UTF-8")
     ca_cert, chain = i.generate_pem_certificate_chain(pub_pem)
     static = {
         "publicKey": pub_pem,
@@ -442,7 +439,7 @@ def write_static_info(i: FakeInstance) -> io.StringIO:
     static[i.uri()] = {
         "pemCertificateChain": chain,
         "caCert": ca_cert,
-        "ipAddress": "127.0.0.1", # "private" IP is localhost in testing
+        "ipAddress": "127.0.0.1",  # "private" IP is localhost in testing
         "publicIpAddress": "",
         "pscInstanceConfig": {"pscDnsName": ""},
     }

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -13,27 +13,23 @@
 # limitations under the License.
 
 import asyncio
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
 import io
 import ipaddress
 import json
 import ssl
 import struct
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Literal, Optional
 
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
-from google.auth.credentials import _helpers
-from google.auth.credentials import TokenState
+from google.auth.credentials import TokenState, _helpers
 from google.auth.transport import requests
 
-from google.cloud.alloydb.connector.connection_info import ConnectionInfo
 import google.cloud.alloydb_connectors_v1.proto.resources_pb2 as connectorspb
+from google.cloud.alloydb.connector.connection_info import ConnectionInfo
 
 
 class FakeCredentials:

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -192,7 +192,7 @@ class FakeInstance:
         ).decode("UTF-8")
         return (pem_root, pem_intermediate, pem_server)
     
-    def generate_pem_certificate_chain(self, pub_key: str) -> Tuple[str, List[str]]:
+    def generate_pem_certificate_chain(self, pub_key: str) -> tuple[str, List[str]]:
         """Generate the CA certificate and certificate chain for the AlloyDB instance."""
         root_cert, intermediate_cert, server_cert = self.get_pem_certs()
         # encode public key to bytes

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -13,23 +13,27 @@
 # limitations under the License.
 
 import asyncio
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 import io
 import ipaddress
 import json
 import ssl
 import struct
-from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Literal, Optional
 
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
-from google.auth.credentials import TokenState, _helpers
+from google.auth.credentials import _helpers
+from google.auth.credentials import TokenState
 from google.auth.transport import requests
 
-import google.cloud.alloydb_connectors_v1.proto.resources_pb2 as connectorspb
 from google.cloud.alloydb.connector.connection_info import ConnectionInfo
+import google.cloud.alloydb_connectors_v1.proto.resources_pb2 as connectorspb
 
 
 class FakeCredentials:

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -149,7 +149,7 @@ class FakeInstance:
         cluster: str = "test-cluster",
         name: str = "test-instance",
         ip_addrs: dict = {
-            "PRIVATE": "127.0.0.1",
+            "PRIVATE": "127.0.0.1",  # "private" IP is localhost in testing
             "PUBLIC": "0.0.0.0",
             "PSC": "x.y.alloydb.goog",
         },
@@ -443,8 +443,8 @@ def write_static_info(i: FakeInstance) -> io.StringIO:
     static[i.uri()] = {
         "pemCertificateChain": chain,
         "caCert": ca_cert,
-        "ipAddress": "127.0.0.1",  # "private" IP is localhost in testing
-        "publicIpAddress": "",
-        "pscInstanceConfig": {"pscDnsName": ""},
+        "ipAddress": i.ip_addrs["PRIVATE"],
+        "publicIpAddress": i.ip_addrs["PUBLIC"],
+        "pscInstanceConfig": {"pscDnsName": i.ip_addrs["PSC"]},
     }
     return io.StringIO(json.dumps(static))

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -16,7 +16,9 @@ import asyncio
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+import io
 import ipaddress
+import json
 import ssl
 import struct
 from typing import Any, Callable, Literal, Optional
@@ -193,6 +195,34 @@ class FakeInstance:
             encoding=serialization.Encoding.PEM
         ).decode("UTF-8")
         return (pem_root, pem_intermediate, pem_server)
+    
+    def generate_pem_certificate_chain(self, pub_key: str) -> Tuple[str, List[str]]:
+        """Generate the CA certificate and certificate chain for the AlloyDB instance."""
+        root_cert, intermediate_cert, server_cert = self.get_pem_certs()
+        # encode public key to bytes
+        pub_key_bytes: rsa.RSAPublicKey = serialization.load_pem_public_key(
+            pub_key.encode("UTF-8"),
+        )
+        # build client cert
+        client_cert = (
+            x509.CertificateBuilder()
+            .subject_name(self.intermediate_cert.subject)
+            .issuer_name(self.intermediate_cert.issuer)
+            .public_key(pub_key_bytes)
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(self.cert_before)
+            .not_valid_after(self.cert_expiry)
+        )
+        # sign client cert with intermediate cert
+        client_cert = client_cert.sign(self.intermediate_key, hashes.SHA256())
+        client_cert = client_cert.public_bytes(
+            encoding=serialization.Encoding.PEM
+        ).decode("UTF-8")
+        return (server_cert, [client_cert, intermediate_cert, root_cert])
+    
+    def uri(self) -> str:
+        """The URI of the AlloyDB instance."""
+        return f"projects/{self.project}/locations/{self.region}/clusters/{self.cluster}/instances/{self.name}"
 
 
 class FakeAlloyDBClient:
@@ -378,3 +408,46 @@ class FakeConnectionInfo:
 
     async def close(self) -> None:
         self._close_called = True
+
+
+def write_static_info(i: FakeInstance) -> io.StringIO:
+    """
+    Creates a static connection info JSON for the StaticConnectionInfoCache.
+
+    Args:
+        i (FakeInstance): The FakeInstance to use to create the CA cert and
+            chain.
+
+    Returns:
+        io.StringIO
+    """
+    priv_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_pem = (
+        priv_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("UTF-8")
+    )
+    priv_pem = (
+        priv_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        .decode("UTF-8")
+    )
+    ca_cert, chain = i.generate_pem_certificate_chain(pub_pem)
+    static = {
+        "publicKey": pub_pem,
+        "privateKey": priv_pem,
+    }
+    static[i.uri()] = {
+        "pemCertificateChain": chain,
+        "caCert": ca_cert,
+        "ipAddress": "127.0.0.1", # "private" IP is localhost in testing
+        "publicIpAddress": "",
+        "pscInstanceConfig": {"pscDnsName": ""},
+    }
+    return io.StringIO(json.dumps(static))

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -192,7 +192,7 @@ class FakeInstance:
         ).decode("UTF-8")
         return (pem_root, pem_intermediate, pem_server)
     
-    def generate_pem_certificate_chain(self, pub_key: str) -> tuple[str, List[str]]:
+    def generate_pem_certificate_chain(self, pub_key: str) -> tuple[str, list[str]]:
         """Generate the CA certificate and certificate chain for the AlloyDB instance."""
         root_cert, intermediate_cert, server_cert = self.get_pem_certs()
         # encode public key to bytes

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -20,7 +20,6 @@ from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeConnectionInfo
 from mocks import FakeCredentials
-from mocks import write_static_info
 import pytest
 
 from google.cloud.alloydb.connector import AsyncConnector
@@ -334,29 +333,3 @@ async def test_Connector_remove_cached_no_ip_type(credentials: FakeCredentials) 
             await connector.connect(instance_uri, "asyncpg", ip_type="private")
         # check that cache has been removed from dict
         assert instance_uri not in connector._cache
-
-
-async def test_Connector_static_connection_info(
-    credentials: FakeCredentials, fake_client: FakeAlloyDBClient
-) -> None:
-    """
-    Test that AsyncConnector.__init__() can specify a static connection info to
-    connect to an instance.
-    """
-    static_info = write_static_info(fake_client.instance)
-    async with AsyncConnector(
-        credentials=credentials, static_conn_info=static_info
-    ) as connector:
-        connector._client = fake_client
-        # patch db connection creation
-        with patch("google.cloud.alloydb.connector.asyncpg.connect") as mock_connect:
-            mock_connect.return_value = True
-            connection = await connector.connect(
-                fake_client.instance.uri(),
-                "asyncpg",
-                user="test-user",
-                password="test-password",
-                db="test-db",
-            )
-        # check connection is returned
-        assert connection is True

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -15,16 +15,13 @@
 import asyncio
 from typing import Union
 
+import pytest
 from aiohttp import ClientResponseError
 from mock import patch
-from mocks import FakeAlloyDBClient
-from mocks import FakeConnectionInfo
-from mocks import FakeCredentials
-from mocks import write_static_info
-import pytest
+from mocks import (FakeAlloyDBClient, FakeConnectionInfo, FakeCredentials,
+                   write_static_info)
 
-from google.cloud.alloydb.connector import AsyncConnector
-from google.cloud.alloydb.connector import IPTypes
+from google.cloud.alloydb.connector import AsyncConnector, IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 
@@ -352,29 +349,6 @@ async def test_Connector_static_connection_info(credentials: FakeCredentials, fa
                 user="test-user",
                 password="test-password",
                 db="test-db",
-            )
-        # check connection is returned
-        assert connection is True
-
-
-async def test_connect_static_connection_info(credentials: FakeCredentials, fake_client: FakeAlloyDBClient) -> None:
-    """
-    Test that AsyncConnector.connect() can specify a static connection info to
-    connect to an instance.
-    """
-    static_info = write_static_info(fake_client.instance)
-    async with AsyncConnector(credentials=credentials) as connector:
-        connector._client = fake_client
-        # patch db connection creation
-        with patch("google.cloud.alloydb.connector.asyncpg.connect") as mock_connect:
-            mock_connect.return_value = True
-            connection = await connector.connect(
-                fake_client.instance.uri(),
-                "asyncpg",
-                user="test-user",
-                password="test-password",
-                db="test-db",
-                static_conn_info=static_info,
             )
         # check connection is returned
         assert connection is True

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -15,17 +15,16 @@
 import asyncio
 from typing import Union
 
-import pytest
 from aiohttp import ClientResponseError
 from mock import patch
-from mocks import (
-    FakeAlloyDBClient,
-    FakeConnectionInfo,
-    FakeCredentials,
-    write_static_info,
-)
+from mocks import FakeAlloyDBClient
+from mocks import FakeConnectionInfo
+from mocks import FakeCredentials
+from mocks import write_static_info
+import pytest
 
-from google.cloud.alloydb.connector import AsyncConnector, IPTypes
+from google.cloud.alloydb.connector import AsyncConnector
+from google.cloud.alloydb.connector import IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -18,8 +18,12 @@ from typing import Union
 import pytest
 from aiohttp import ClientResponseError
 from mock import patch
-from mocks import (FakeAlloyDBClient, FakeConnectionInfo, FakeCredentials,
-                   write_static_info)
+from mocks import (
+    FakeAlloyDBClient,
+    FakeConnectionInfo,
+    FakeCredentials,
+    write_static_info,
+)
 
 from google.cloud.alloydb.connector import AsyncConnector, IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
@@ -332,13 +336,18 @@ async def test_Connector_remove_cached_no_ip_type(credentials: FakeCredentials) 
         # check that cache has been removed from dict
         assert instance_uri not in connector._cache
 
-async def test_Connector_static_connection_info(credentials: FakeCredentials, fake_client: FakeAlloyDBClient) -> None:
+
+async def test_Connector_static_connection_info(
+    credentials: FakeCredentials, fake_client: FakeAlloyDBClient
+) -> None:
     """
     Test that AsyncConnector.__init__() can specify a static connection info to
     connect to an instance.
     """
     static_info = write_static_info(fake_client.instance)
-    async with AsyncConnector(credentials=credentials, static_conn_info=static_info) as connector:
+    async with AsyncConnector(
+        credentials=credentials, static_conn_info=static_info
+    ) as connector:
         connector._client = fake_client
         # patch db connection creation
         with patch("google.cloud.alloydb.connector.asyncpg.connect") as mock_connect:

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -20,6 +20,7 @@ from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeConnectionInfo
 from mocks import FakeCredentials
+from mocks import write_static_info
 import pytest
 
 from google.cloud.alloydb.connector import AsyncConnector
@@ -333,3 +334,47 @@ async def test_Connector_remove_cached_no_ip_type(credentials: FakeCredentials) 
             await connector.connect(instance_uri, "asyncpg", ip_type="private")
         # check that cache has been removed from dict
         assert instance_uri not in connector._cache
+
+async def test_Connector_static_connection_info(credentials: FakeCredentials, fake_client: FakeAlloyDBClient) -> None:
+    """
+    Test that AsyncConnector.__init__() can specify a static connection info to
+    connect to an instance.
+    """
+    static_info = write_static_info(fake_client.instance)
+    async with AsyncConnector(credentials=credentials, static_conn_info=static_info) as connector:
+        connector._client = fake_client
+        # patch db connection creation
+        with patch("google.cloud.alloydb.connector.asyncpg.connect") as mock_connect:
+            mock_connect.return_value = True
+            connection = await connector.connect(
+                fake_client.instance.uri(),
+                "asyncpg",
+                user="test-user",
+                password="test-password",
+                db="test-db",
+            )
+        # check connection is returned
+        assert connection is True
+
+
+async def test_connect_static_connection_info(credentials: FakeCredentials, fake_client: FakeAlloyDBClient) -> None:
+    """
+    Test that AsyncConnector.connect() can specify a static connection info to
+    connect to an instance.
+    """
+    static_info = write_static_info(fake_client.instance)
+    async with AsyncConnector(credentials=credentials) as connector:
+        connector._client = fake_client
+        # patch db connection creation
+        with patch("google.cloud.alloydb.connector.asyncpg.connect") as mock_connect:
+            mock_connect.return_value = True
+            connection = await connector.connect(
+                fake_client.instance.uri(),
+                "asyncpg",
+                user="test-user",
+                password="test-password",
+                db="test-db",
+                static_conn_info=static_info,
+            )
+        # check connection is returned
+        assert connection is True

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -249,7 +249,9 @@ async def test_Connector_remove_cached_no_ip_type(credentials: FakeCredentials) 
 
 
 @pytest.mark.usefixtures("proxy_server")
-def test_Connector_static_connection_info(credentials: FakeCredentials, fake_client: FakeAlloyDBClient) -> None:
+def test_Connector_static_connection_info(
+    credentials: FakeCredentials, fake_client: FakeAlloyDBClient
+) -> None:
     """
     Test that Connector.__init__() can specify a static connection info to
     connect to an instance.

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -16,15 +16,12 @@ import asyncio
 from threading import Thread
 from typing import Union
 
+import pytest
 from aiohttp import ClientResponseError
 from mock import patch
-from mocks import FakeAlloyDBClient
-from mocks import FakeCredentials
-from mocks import write_static_info
-import pytest
+from mocks import FakeAlloyDBClient, FakeCredentials, write_static_info
 
-from google.cloud.alloydb.connector import Connector
-from google.cloud.alloydb.connector import IPTypes
+from google.cloud.alloydb.connector import Connector, IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.utils import generate_keys
@@ -269,30 +266,6 @@ def test_Connector_static_connection_info(credentials: FakeCredentials, fake_cli
                 user="test-user",
                 password="test-password",
                 db="test-db",
-            )
-        # check connection is returned
-        assert connection is True
-
-
-@pytest.mark.usefixtures("proxy_server")
-def test_connect_static_connection_info(credentials: FakeCredentials, fake_client: FakeAlloyDBClient) -> None:
-    """
-    Test that Connector.connect() can specify a static connection info to
-    connect to an instance.
-    """
-    static_info = write_static_info(fake_client.instance)
-    with Connector(credentials=credentials) as connector:
-        connector._client = fake_client
-        # patch db connection creation
-        with patch("google.cloud.alloydb.connector.pg8000.connect") as mock_connect:
-            mock_connect.return_value = True
-            connection = connector.connect(
-                fake_client.instance.uri(),
-                "pg8000",
-                user="test-user",
-                password="test-password",
-                db="test-db",
-                static_conn_info=static_info,
             )
         # check connection is returned
         assert connection is True

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -20,6 +20,7 @@ from aiohttp import ClientResponseError
 from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeCredentials
+from mocks import write_static_info
 import pytest
 
 from google.cloud.alloydb.connector import Connector
@@ -248,3 +249,50 @@ async def test_Connector_remove_cached_no_ip_type(credentials: FakeCredentials) 
             await connector.connect_async(instance_uri, "pg8000", ip_type="private")
         # check that cache has been removed from dict
         assert instance_uri not in connector._cache
+
+
+@pytest.mark.usefixtures("proxy_server")
+def test_Connector_static_connection_info(credentials: FakeCredentials, fake_client: FakeAlloyDBClient) -> None:
+    """
+    Test that Connector.__init__() can specify a static connection info to
+    connect to an instance.
+    """
+    static_info = write_static_info(fake_client.instance)
+    with Connector(credentials=credentials, static_conn_info=static_info) as connector:
+        connector._client = fake_client
+        # patch db connection creation
+        with patch("google.cloud.alloydb.connector.pg8000.connect") as mock_connect:
+            mock_connect.return_value = True
+            connection = connector.connect(
+                fake_client.instance.uri(),
+                "pg8000",
+                user="test-user",
+                password="test-password",
+                db="test-db",
+            )
+        # check connection is returned
+        assert connection is True
+
+
+@pytest.mark.usefixtures("proxy_server")
+def test_connect_static_connection_info(credentials: FakeCredentials, fake_client: FakeAlloyDBClient) -> None:
+    """
+    Test that Connector.connect() can specify a static connection info to
+    connect to an instance.
+    """
+    static_info = write_static_info(fake_client.instance)
+    with Connector(credentials=credentials) as connector:
+        connector._client = fake_client
+        # patch db connection creation
+        with patch("google.cloud.alloydb.connector.pg8000.connect") as mock_connect:
+            mock_connect.return_value = True
+            connection = connector.connect(
+                fake_client.instance.uri(),
+                "pg8000",
+                user="test-user",
+                password="test-password",
+                db="test-db",
+                static_conn_info=static_info,
+            )
+        # check connection is returned
+        assert connection is True

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -16,12 +16,15 @@ import asyncio
 from threading import Thread
 from typing import Union
 
-import pytest
 from aiohttp import ClientResponseError
 from mock import patch
-from mocks import FakeAlloyDBClient, FakeCredentials, write_static_info
+from mocks import FakeAlloyDBClient
+from mocks import FakeCredentials
+from mocks import write_static_info
+import pytest
 
-from google.cloud.alloydb.connector import Connector, IPTypes
+from google.cloud.alloydb.connector import Connector
+from google.cloud.alloydb.connector import IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.utils import generate_keys

--- a/tests/unit/test_static.py
+++ b/tests/unit/test_static.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mocks import FakeInstance, write_static_info
+from mocks import FakeInstance
+from mocks import write_static_info
 
 from google.cloud.alloydb.connector.connection_info import ConnectionInfo
 from google.cloud.alloydb.connector.static import StaticConnectionInfoCache
@@ -36,6 +37,7 @@ def test_StaticConnectionInfoCache_init() -> None:
     }
     assert cache._info.expiration
 
+
 def test_StaticConnectionInfoCache_init_trailing_dot_dns() -> None:
     """
     Test that StaticConnectionInfoCache.__init__ populates its ConnectionInfo
@@ -56,6 +58,7 @@ def test_StaticConnectionInfoCache_init_trailing_dot_dns() -> None:
     }
     assert cache._info.expiration
 
+
 async def test_StaticConnectionInfoCache_force_refresh() -> None:
     """
     Test that StaticConnectionInfoCache.force_refresh is a no-op.
@@ -68,19 +71,22 @@ async def test_StaticConnectionInfoCache_force_refresh() -> None:
     conn_info2 = cache._info
     assert conn_info2 == conn_info
 
+
 async def test_StaticConnectionInfoCache_connect_info() -> None:
     """
-    Test that StaticConnectionInfoCache.connect_info works as expected.
+    Test that StaticConnectionInfoCache.connect_info returns the ConnectionInfo
+    object.
     """
     i = FakeInstance()
     static_info = write_static_info(i)
     cache = StaticConnectionInfoCache(i.uri(), static_info)
     # check that cached connection info is now set
     assert isinstance(cache._info, ConnectionInfo)
-    conn_info = await cache.connect_info()
+    conn_info = cache._info
     # check that calling connect_info uses cached info
     conn_info2 = await cache.connect_info()
     assert conn_info2 == conn_info
+
 
 async def test_StaticConnectionInfoCache_close() -> None:
     """

--- a/tests/unit/test_static.py
+++ b/tests/unit/test_static.py
@@ -1,0 +1,95 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mocks import FakeInstance, write_static_info
+
+from google.cloud.alloydb.connector.connection_info import ConnectionInfo
+from google.cloud.alloydb.connector.static import StaticConnectionInfoCache
+
+
+def test_StaticConnectionInfoCache_init() -> None:
+    """
+    Test that StaticConnectionInfoCache.__init__ populates its ConnectionInfo
+    object.
+    """
+    i = FakeInstance()
+    static_info = write_static_info(i)
+    cache = StaticConnectionInfoCache(i.uri(), static_info)
+    assert len(cache._info.cert_chain) == 3
+    assert cache._info.ca_cert
+    assert cache._info.key
+    assert cache._info.ip_addrs == {
+        "PRIVATE": i.ip_addrs["PRIVATE"],
+        "PUBLIC": i.ip_addrs["PUBLIC"],
+        "PSC": i.ip_addrs["PSC"],
+    }
+    assert cache._info.expiration
+
+def test_StaticConnectionInfoCache_init_trailing_dot_dns() -> None:
+    """
+    Test that StaticConnectionInfoCache.__init__ populates its ConnectionInfo
+    object correctly when its PSC DNS name contains a trailing dot.
+    """
+    i = FakeInstance()
+    no_trailing_dot_dns = i.ip_addrs["PSC"]
+    i.ip_addrs["PSC"] += "."
+    static_info = write_static_info(i)
+    cache = StaticConnectionInfoCache(i.uri(), static_info)
+    assert len(cache._info.cert_chain) == 3
+    assert cache._info.ca_cert
+    assert cache._info.key
+    assert cache._info.ip_addrs == {
+        "PRIVATE": i.ip_addrs["PRIVATE"],
+        "PUBLIC": i.ip_addrs["PUBLIC"],
+        "PSC": no_trailing_dot_dns,
+    }
+    assert cache._info.expiration
+
+async def test_StaticConnectionInfoCache_force_refresh() -> None:
+    """
+    Test that StaticConnectionInfoCache.force_refresh is a no-op.
+    """
+    i = FakeInstance()
+    static_info = write_static_info(i)
+    cache = StaticConnectionInfoCache(i.uri(), static_info)
+    conn_info = cache._info
+    await cache.force_refresh()
+    conn_info2 = cache._info
+    assert conn_info2 == conn_info
+
+async def test_StaticConnectionInfoCache_connect_info() -> None:
+    """
+    Test that StaticConnectionInfoCache.connect_info works as expected.
+    """
+    i = FakeInstance()
+    static_info = write_static_info(i)
+    cache = StaticConnectionInfoCache(i.uri(), static_info)
+    # check that cached connection info is now set
+    assert isinstance(cache._info, ConnectionInfo)
+    conn_info = await cache.connect_info()
+    # check that calling connect_info uses cached info
+    conn_info2 = await cache.connect_info()
+    assert conn_info2 == conn_info
+
+async def test_StaticConnectionInfoCache_close() -> None:
+    """
+    Test that StaticConnectionInfoCache.close is a no-op.
+    """
+    i = FakeInstance()
+    static_info = write_static_info(i)
+    cache = StaticConnectionInfoCache(i.uri(), static_info)
+    conn_info = cache._info
+    await cache.close()
+    conn_info2 = cache._info
+    assert conn_info2 == conn_info


### PR DESCRIPTION
This is a port of https://github.com/GoogleCloudPlatform/alloydb-go-connector/pull/572 for the AlloyDB Python connector. It allows connecting to a sandbox AlloyDB instance using connection info properties from a JSON file, instead of calling the AlloyDB APIs to get this information (which is done by the internal and lazy caches).

Using a static connection info currently works for the sync client (`pg8000`), but doesn't work for the async client (`asyncpg`). When using the async client, getting timeout errors [here](https://github.com/MagicStack/asyncpg/blob/master/asyncpg/connection.py#L2420), due to [ConnectionDoesNotExistError](https://github.com/MagicStack/asyncpg/blob/master/asyncpg/connect_utils.py#L962). This is fine for now, as long as we can use the Python connector (using the sync client) to connect to a sandbox AlloyDB instance.