### PR TITLE
feat: Replace aiohttp.ClientSession with AlloyDBAdminAsyncClient

### DIFF
--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -31,7 +31,6 @@ from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.lazy import LazyRefreshCache
 from google.cloud.alloydb.connector.types import CacheTypes
 from google.cloud.alloydb.connector.utils import generate_keys
-import traceback
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials
@@ -183,7 +182,6 @@ class AsyncConnector:
             conn_info = await cache.connect_info()
             ip_address = conn_info.get_preferred_ip(ip_type)
         except Exception:
-            print(f"RISHABH DEBUG: exception = {traceback.print_exc()}")
             # with an error from AlloyDB API call or IP type, invalidate the
             # cache and re-raise the error
             await self._remove_cached(instance_uri)

--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -31,6 +31,7 @@ from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.lazy import LazyRefreshCache
 from google.cloud.alloydb.connector.types import CacheTypes
 from google.cloud.alloydb.connector.utils import generate_keys
+import traceback
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials
@@ -182,6 +183,7 @@ class AsyncConnector:
             conn_info = await cache.connect_info()
             ip_address = conn_info.get_preferred_ip(ip_type)
         except Exception:
+            print(f"RISHABH DEBUG: exception = {traceback.print_exc()}")
             # with an error from AlloyDB API call or IP type, invalidate the
             # cache and re-raise the error
             await self._remove_cached(instance_uri)

--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -67,7 +67,7 @@ class AsyncConnector:
         self,
         credentials: Optional[Credentials] = None,
         quota_project: Optional[str] = None,
-        alloydb_api_endpoint: str = "https://alloydb.googleapis.com",
+        alloydb_api_endpoint: str = "alloydb.googleapis.com",
         enable_iam_auth: bool = False,
         ip_type: str | IPTypes = IPTypes.PRIVATE,
         user_agent: Optional[str] = None,

--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -235,5 +235,3 @@ class AsyncConnector:
         """Helper function to cancel RefreshAheadCaches' tasks
         and close client."""
         await asyncio.gather(*[cache.close() for cache in self._cache.values()])
-        if self._client:
-            await self._client.close()

--- a/google/cloud/alloydb/connector/async_connector.py
+++ b/google/cloud/alloydb/connector/async_connector.py
@@ -31,6 +31,7 @@ from google.cloud.alloydb.connector.instance import RefreshAheadCache
 from google.cloud.alloydb.connector.lazy import LazyRefreshCache
 from google.cloud.alloydb.connector.types import CacheTypes
 from google.cloud.alloydb.connector.utils import generate_keys
+from google.cloud.alloydb.connector.utils import strip_http_prefix
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials
@@ -51,7 +52,7 @@ class AsyncConnector:
             billing purposes.
             Defaults to None, picking up project from environment.
         alloydb_api_endpoint (str): Base URL to use when calling
-            the AlloyDB API endpoint. Defaults to "https://alloydb.googleapis.com".
+            the AlloyDB API endpoint. Defaults to "alloydb.googleapis.com".
         enable_iam_auth (bool): Enables automatic IAM database authentication.
         ip_type (str | IPTypes): Default IP type for all AlloyDB connections.
             Defaults to IPTypes.PRIVATE ("PRIVATE") for private IP connections.
@@ -75,7 +76,7 @@ class AsyncConnector:
         self._cache: dict[str, CacheTypes] = {}
         # initialize default params
         self._quota_project = quota_project
-        self._alloydb_api_endpoint = alloydb_api_endpoint
+        self._alloydb_api_endpoint = strip_http_prefix(alloydb_api_endpoint)
         self._enable_iam_auth = enable_iam_auth
         # if ip_type is str, convert to IPTypes enum
         if isinstance(ip_type, str):

--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -23,11 +23,11 @@ from google.api_core.client_options import ClientOptions
 from google.api_core.gapic_v1.client_info import ClientInfo
 from google.auth.credentials import TokenState
 from google.auth.transport import requests
+import google.cloud.alloydb_v1beta as v1beta
+from google.protobuf import duration_pb2
 
-from google.cloud import alloydb_v1beta
 from google.cloud.alloydb.connector.connection_info import ConnectionInfo
 from google.cloud.alloydb.connector.version import __version__ as version
-from google.protobuf import duration_pb2
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials
@@ -58,7 +58,7 @@ class AlloyDBClient:
         alloydb_api_endpoint: str,
         quota_project: Optional[str],
         credentials: Credentials,
-        client: Optional[alloydb_v1beta.AlloyDBAdminAsyncClient] = None,
+        client: Optional[v1beta.AlloyDBAdminAsyncClient] = None,
         driver: Optional[str] = None,
         user_agent: Optional[str] = None,
     ) -> None:
@@ -75,22 +75,26 @@ class AlloyDBClient:
                 A credentials object created from the google-auth Python library.
                 Must have the AlloyDB Admin scopes. For more info check out
                 https://google-auth.readthedocs.io/en/latest/.
-            client (alloydb_v1beta.AlloyDBAdminAsyncClient): Async client used to
-                make requests to AlloyDB APIs.
+            client (v1beta.AlloyDBAdminAsyncClient): Async client used to make
+                requests to AlloyDB APIs.
                 Optional, defaults to None and creates new client.
             driver (str): Database driver to be used by the client.
         """
         user_agent = _format_user_agent(driver, user_agent)
 
-        self._client = client if client else alloydb_v1beta.AlloyDBAdminAsyncClient(
-            credentials=credentials,
-            client_options=ClientOptions(
-                api_endpoint=alloydb_api_endpoint,
-                quota_project_id=quota_project,
-            ),
-            client_info=ClientInfo(
-                user_agent=user_agent,
-            ),
+        self._client = (
+            client
+            if client
+            else v1beta.AlloyDBAdminAsyncClient(
+                credentials=credentials,
+                client_options=ClientOptions(
+                    api_endpoint=alloydb_api_endpoint,
+                    quota_project_id=quota_project,
+                ),
+                client_info=ClientInfo(
+                    user_agent=user_agent,
+                ),
+            )
         )
         self._credentials = credentials
         # asyncpg does not currently support using metadata exchange
@@ -122,9 +126,11 @@ class AlloyDBClient:
         Returns:
             dict: IP addresses of the AlloyDB instance.
         """
-        parent = f"projects/{project}/locations/{region}/clusters/{cluster}/instances/{name}"
+        parent = (
+            f"projects/{project}/locations/{region}/clusters/{cluster}/instances/{name}"
+        )
 
-        req = alloydb_v1beta.GetConnectionInfoRequest(parent=parent)
+        req = v1beta.GetConnectionInfoRequest(parent=parent)
         resp = await self._client.get_connection_info(request=req)
 
         # Remove trailing period from PSC DNS name.
@@ -166,7 +172,7 @@ class AlloyDBClient:
         parent = f"projects/{project}/locations/{region}/clusters/{cluster}"
         dur = duration_pb2.Duration()
         dur.seconds = 3600
-        req = alloydb_v1beta.GenerateClientCertificateRequest(
+        req = v1beta.GenerateClientCertificateRequest(
             parent=parent,
             cert_duration=dur,
             public_key=pub_key,

--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -85,7 +85,7 @@ class AlloyDBClient:
         self._client = client if client else alloydb_v1beta.AlloyDBAdminAsyncClient(
             credentials=credentials,
             client_options=ClientOptions(
-                api_endpoint=alloydb_api_endpoint,
+                api_endpoint="alloydb.googleapis.com",
                 quota_project_id=quota_project,
             ),
             client_info=ClientInfo(
@@ -123,11 +123,10 @@ class AlloyDBClient:
         Returns:
             dict: IP addresses of the AlloyDB instance.
         """
-        parent = f"{self._alloydb_api_endpoint}/{API_VERSION}/projects/{project}/locations/{region}/clusters/{cluster}/instances/{name}"
+        parent = f"projects/{project}/locations/{region}/clusters/{cluster}/instances/{name}"
 
         req = alloydb_v1beta.GetConnectionInfoRequest(parent=parent)
         resp = await self._client.get_connection_info(request=req)
-        resp = await resp
         # # try to get response json for better error message
         # try:
         #     resp_dict = await resp.json()
@@ -178,7 +177,7 @@ class AlloyDBClient:
             tuple[str, list[str]]: tuple containing the CA certificate
                 and certificate chain for the AlloyDB instance.
         """
-        parent = f"{self._alloydb_api_endpoint}/{API_VERSION}/projects/{project}/locations/{region}/clusters/{cluster}"
+        parent = f"projects/{project}/locations/{region}/clusters/{cluster}"
         dur = duration_pb2.Duration()
         dur.seconds = 3600
         req = alloydb_v1beta.GenerateClientCertificateRequest(
@@ -188,7 +187,6 @@ class AlloyDBClient:
             use_metadata_exchange=self._use_metadata,
         )
         resp = await self._client.generate_client_certificate(request=req)
-        resp = await resp
         # # try to get response json for better error message
         # try:
         #     resp_dict = await resp.json()

--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -244,7 +244,3 @@ class AlloyDBClient:
             ip_addrs,
             expiration,
         )
-
-    async def close(self) -> None:
-        """Close AlloyDBClient gracefully."""
-        logger.debug("Closed AlloyDBClient")

--- a/google/cloud/alloydb/connector/client.py
+++ b/google/cloud/alloydb/connector/client.py
@@ -96,6 +96,7 @@ class AlloyDBClient:
         # asyncpg does not currently support using metadata exchange
         # only use metadata exchange for pg8000 driver
         self._use_metadata = True if driver == "pg8000" else False
+        self._user_agent = user_agent
 
     async def _get_metadata(
         self,

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -64,7 +64,7 @@ class Connector:
             billing purposes.
             Defaults to None, picking up project from environment.
         alloydb_api_endpoint (str): Base URL to use when calling
-            the AlloyDB API endpoint. Defaults to "https://alloydb.googleapis.com".
+            the AlloyDB API endpoint. Defaults to "alloydb.googleapis.com".
         enable_iam_auth (bool): Enables automatic IAM database authentication.
         ip_type (str | IPTypes): Default IP type for all AlloyDB connections.
             Defaults to IPTypes.PRIVATE ("PRIVATE") for private IP connections.
@@ -85,7 +85,7 @@ class Connector:
         self,
         credentials: Optional[Credentials] = None,
         quota_project: Optional[str] = None,
-        alloydb_api_endpoint: str = "https://alloydb.googleapis.com",
+        alloydb_api_endpoint: str = "alloydb.googleapis.com",
         enable_iam_auth: bool = False,
         ip_type: str | IPTypes = IPTypes.PRIVATE,
         user_agent: Optional[str] = None,

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -37,6 +37,7 @@ from google.cloud.alloydb.connector.lazy import LazyRefreshCache
 import google.cloud.alloydb.connector.pg8000 as pg8000
 from google.cloud.alloydb.connector.types import CacheTypes
 from google.cloud.alloydb.connector.utils import generate_keys
+from google.cloud.alloydb.connector.utils import strip_http_prefix
 import google.cloud.alloydb_connectors_v1.proto.resources_pb2 as connectorspb
 
 if TYPE_CHECKING:
@@ -99,7 +100,7 @@ class Connector:
         self._cache: dict[str, CacheTypes] = {}
         # initialize default params
         self._quota_project = quota_project
-        self._alloydb_api_endpoint = alloydb_api_endpoint
+        self._alloydb_api_endpoint = strip_http_prefix(alloydb_api_endpoint)
         self._enable_iam_auth = enable_iam_auth
         # if ip_type is str, convert to IPTypes enum
         if isinstance(ip_type, str):

--- a/google/cloud/alloydb/connector/connector.py
+++ b/google/cloud/alloydb/connector/connector.py
@@ -392,5 +392,3 @@ class Connector:
         """Helper function to cancel RefreshAheadCaches' tasks
         and close client."""
         await asyncio.gather(*[cache.close() for cache in self._cache.values()])
-        if self._client:
-            await self._client.close()

--- a/google/cloud/alloydb/connector/utils.py
+++ b/google/cloud/alloydb/connector/utils.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import re
+
 import aiofiles
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -58,3 +60,13 @@ async def generate_keys() -> tuple[rsa.RSAPrivateKey, str]:
         .decode("UTF-8")
     )
     return (priv_key, pub_key)
+
+
+def strip_http_prefix(url: str) -> str:
+    """
+    Returns a new URL with 'http://' or 'https://' prefix removed.
+    """
+    m = re.search(r"^(https?://)?(.+)", url)
+    if m is None:
+        return ""
+    return m.group(2)

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,3 +11,9 @@ ignore_missing_imports = True
 
 [mypy-asyncpg]
 ignore_missing_imports = True
+
+[mypy-google.cloud.alloydb_v1beta]
+ignore_missing_imports = True
+
+[mypy-google.api_core.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==24.1.0
 aiohttp==3.11.13
-cryptography==44.0.2
+cryptography==44.0.0
 google-auth==2.38.0
 requests==2.32.3
 protobuf==6.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==24.1.0
 aiohttp==3.11.13
-cryptography==44.0.0
+cryptography==44.0.2
 google-auth==2.38.0
 requests==2.32.3
 protobuf==6.30.0

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -23,10 +23,10 @@ import ssl
 import struct
 from typing import Any, Callable, Literal, Optional
 
-from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+import cryptography.x509 as x509
 from cryptography.x509.oid import NameOID
 from google.auth.credentials import _helpers
 from google.auth.credentials import TokenState

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -233,7 +233,6 @@ class FakeAlloyDBClient:
         self, instance: Optional[FakeInstance] = None, driver: str = "pg8000"
     ) -> None:
         self.instance = FakeInstance() if instance is None else instance
-        self.closed = False
         self._user_agent = f"test-user-agent+{driver}"
         self._credentials = FakeCredentials()
 
@@ -317,9 +316,6 @@ class FakeAlloyDBClient:
             ip_addrs,
             expiration,
         )
-
-    async def close(self) -> None:
-        self.closed = True
 
 
 def metadata_exchange(sock: ssl.SSLSocket) -> None:
@@ -466,14 +462,12 @@ class FakeAlloyDBAdminAsyncClient:
         if instance == "test-instance":
             ci.public_ip_address = ""
             ci.psc_dns_name = ""
-            return ci
         elif instance == "public-instance":
             ci.psc_dns_name = ""
-            return ci
         else:
             ci.ip_address = ""
             ci.public_ip_address = ""
-            return ci
+        return ci
 
     async def generate_client_certificate(
         self, request: alloydb_v1beta.GenerateClientCertificateRequest

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -32,6 +32,7 @@ from google.auth.credentials import _helpers
 from google.auth.credentials import TokenState
 from google.auth.transport import requests
 
+from google.cloud import alloydb_v1beta
 from google.cloud.alloydb.connector.connection_info import ConnectionInfo
 import google.cloud.alloydb_connectors_v1.proto.resources_pb2 as connectorspb
 
@@ -448,3 +449,34 @@ def write_static_info(i: FakeInstance) -> io.StringIO:
         "pscInstanceConfig": {"pscDnsName": i.ip_addrs["PSC"]},
     }
     return io.StringIO(json.dumps(static))
+
+
+class FakeAlloyDBAdminAsyncClient:
+    async def get_connection_info(self, request: alloydb_v1beta.GetConnectionInfoRequest) -> alloydb_v1beta.types.resources.ConnectionInfo:
+        ci = alloydb_v1beta.types.resources.ConnectionInfo()
+        ci.ip_address = "10.0.0.1"
+        ci.public_ip_address = "127.0.0.1"
+        ci.instance_uid = "123456789"
+        ci.psc_dns_name = "x.y.alloydb.goog"
+
+        parent = request.parent
+        instance = parent.split("/")[-1]
+        if instance == "test-instance":
+            ci.public_ip_address = ""
+            ci.psc_dns_name = ""
+            return ci
+        elif instance == "public-instance":
+            ci.psc_dns_name = ""
+            return ci
+        else:
+            ci.ip_address = ""
+            ci.public_ip_address = ""
+            return ci
+
+    async def generate_client_certificate(self, request: alloydb_v1beta.GenerateClientCertificateRequest) -> alloydb_v1beta.types.service.GenerateClientCertificateResponse:
+        ccr = alloydb_v1beta.types.service.GenerateClientCertificateResponse()
+        ccr.ca_cert = "This is the CA cert"
+        ccr.pem_certificate_chain.append("This is the client cert")
+        ccr.pem_certificate_chain.append("This is the intermediate cert")
+        ccr.pem_certificate_chain.append("This is the root cert")
+        return ccr

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -23,10 +23,19 @@ import ssl
 import struct
 from typing import Any, Callable, Literal, Optional
 
+from cryptography.x509 import (
+    CertificateBuilder as x509_CertificateBuilder,
+    NameAttribute as x509_NameAttribute,
+    random_serial_number as x509_random_serial_number,
+    SubjectAlternativeName as x509_SubjectAlternativeName,
+    IPAddress as x509_IPAddress,
+    DNSName as x509_DNSName,
+    load_pem_x509_certificate as x509_load_pem_x509_certificate,
+    Name as x509_Name,
+)
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-import cryptography.x509 as x509
 from cryptography.x509.oid import NameOID
 from google.auth.credentials import _helpers
 from google.auth.credentials import TokenState
@@ -89,7 +98,7 @@ class FakeCredentials:
 
 def generate_cert(
     common_name: str, expires_in: int = 60, server_cert: bool = False
-) -> tuple[x509.CertificateBuilder, rsa.RSAPrivateKey]:
+) -> tuple[x509_CertificateBuilder, rsa.RSAPrivateKey]:
     """
     Generate a private key and cert object to be used in testing.
 
@@ -99,7 +108,7 @@ def generate_cert(
         server_cert (bool): Whether it is a server certificate.
 
     Returns:
-        tuple[x509.CertificateBuilder, rsa.RSAPrivateKey]
+        tuple[x509_CertificateBuilder, rsa.RSAPrivateKey]
     """
     # generate private key
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
@@ -107,32 +116,32 @@ def generate_cert(
     now = datetime.now(timezone.utc)
     expiration = now + timedelta(minutes=expires_in)
     # configure cert subject
-    subject = issuer = x509.Name(
+    subject = issuer = x509_Name(
         [
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "California"),
-            x509.NameAttribute(NameOID.LOCALITY_NAME, "Mountain View"),
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Google Inc"),
-            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+            x509_NameAttribute(NameOID.COUNTRY_NAME, "US"),
+            x509_NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "California"),
+            x509_NameAttribute(NameOID.LOCALITY_NAME, "Mountain View"),
+            x509_NameAttribute(NameOID.ORGANIZATION_NAME, "Google Inc"),
+            x509_NameAttribute(NameOID.COMMON_NAME, common_name),
         ]
     )
     # build cert
     cert = (
-        x509.CertificateBuilder()
+        x509_CertificateBuilder()
         .subject_name(subject)
         .issuer_name(issuer)
         .public_key(key.public_key())
-        .serial_number(x509.random_serial_number())
+        .serial_number(x509_random_serial_number())
         .not_valid_before(now)
         .not_valid_after(expiration)
     )
     if server_cert:
         cert = cert.add_extension(
-            x509.SubjectAlternativeName(
+            x509_SubjectAlternativeName(
                 general_names=[
-                    x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
-                    x509.IPAddress(ipaddress.ip_address("10.0.0.1")),
-                    x509.DNSName("x.y.alloydb.goog."),
+                    x509_IPAddress(ipaddress.ip_address("127.0.0.1")),
+                    x509_IPAddress(ipaddress.ip_address("10.0.0.1")),
+                    x509_DNSName("x.y.alloydb.goog."),
                 ]
             ),
             critical=False,
@@ -206,11 +215,11 @@ class FakeInstance:
         )
         # build client cert
         client_cert = (
-            x509.CertificateBuilder()
+            x509_CertificateBuilder()
             .subject_name(self.intermediate_cert.subject)
             .issuer_name(self.intermediate_cert.issuer)
             .public_key(pub_key_bytes)
-            .serial_number(x509.random_serial_number())
+            .serial_number(x509_random_serial_number())
             .not_valid_before(self.cert_before)
             .not_valid_after(self.cert_expiry)
         )
@@ -253,11 +262,11 @@ class FakeAlloyDBClient:
         )
         # build client cert
         client_cert = (
-            x509.CertificateBuilder()
+            x509_CertificateBuilder()
             .subject_name(self.instance.intermediate_cert.subject)
             .issuer_name(self.instance.intermediate_cert.issuer)
             .public_key(pub_key_bytes)
-            .serial_number(x509.random_serial_number())
+            .serial_number(x509_random_serial_number())
             .not_valid_before(self.instance.cert_before)
             .not_valid_after(self.instance.cert_expiry)
         )
@@ -306,7 +315,7 @@ class FakeAlloyDBClient:
         # unpack certs
         ca_cert, cert_chain = certs
         # get expiration from client certificate
-        cert_obj = x509.load_pem_x509_certificate(cert_chain[0].encode("UTF-8"))
+        cert_obj = x509_load_pem_x509_certificate(cert_chain[0].encode("UTF-8"))
         expiration = cert_obj.not_valid_after_utc
 
         return ConnectionInfo(

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -452,7 +452,9 @@ def write_static_info(i: FakeInstance) -> io.StringIO:
 
 
 class FakeAlloyDBAdminAsyncClient:
-    async def get_connection_info(self, request: alloydb_v1beta.GetConnectionInfoRequest) -> alloydb_v1beta.types.resources.ConnectionInfo:
+    async def get_connection_info(
+        self, request: alloydb_v1beta.GetConnectionInfoRequest
+    ) -> alloydb_v1beta.types.resources.ConnectionInfo:
         ci = alloydb_v1beta.types.resources.ConnectionInfo()
         ci.ip_address = "10.0.0.1"
         ci.public_ip_address = "127.0.0.1"
@@ -473,7 +475,9 @@ class FakeAlloyDBAdminAsyncClient:
             ci.public_ip_address = ""
             return ci
 
-    async def generate_client_certificate(self, request: alloydb_v1beta.GenerateClientCertificateRequest) -> alloydb_v1beta.types.service.GenerateClientCertificateResponse:
+    async def generate_client_certificate(
+        self, request: alloydb_v1beta.GenerateClientCertificateRequest
+    ) -> alloydb_v1beta.types.service.GenerateClientCertificateResponse:
         ccr = alloydb_v1beta.types.service.GenerateClientCertificateResponse()
         ccr.ca_cert = "This is the CA cert"
         ccr.pem_certificate_chain.append("This is the client cert")

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -109,6 +109,26 @@ async def test_AsyncConnector_init_bad_ip_type(credentials: FakeCredentials) -> 
     )
 
 
+def test_AsyncConnector_init_alloydb_api_endpoint_with_http_prefix() -> None:
+    """
+    Test to check whether the __init__ method of AsyncConnector properly sets
+    alloydb_api_endpoint when its URL has an 'http://' prefix.
+    """
+    connector = AsyncConnector(alloydb_api_endpoint="http://alloydb.googleapis.com")
+    assert connector._alloydb_api_endpoint == "alloydb.googleapis.com"
+    connector.close()
+
+
+def test_AsyncConnector_init_alloydb_api_endpoint_with_https_prefix() -> None:
+    """
+    Test to check whether the __init__ method of AsyncConnector properly sets
+    alloydb_api_endpoint when its URL has an 'https://' prefix.
+    """
+    connector = AsyncConnector(alloydb_api_endpoint="https://alloydb.googleapis.com")
+    assert connector._alloydb_api_endpoint == "alloydb.googleapis.com"
+    connector.close()
+
+
 @pytest.mark.asyncio
 async def test_AsyncConnector_context_manager(
     credentials: FakeCredentials,

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -15,13 +15,13 @@
 import asyncio
 from typing import Union
 
+from google.api_core.exceptions import RetryError
 from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeConnectionInfo
 from mocks import FakeCredentials
 import pytest
 
-from google.api_core.exceptions import RetryError
 from google.cloud.alloydb.connector import AsyncConnector
 from google.cloud.alloydb.connector import IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -109,22 +109,30 @@ async def test_AsyncConnector_init_bad_ip_type(credentials: FakeCredentials) -> 
     )
 
 
-def test_AsyncConnector_init_alloydb_api_endpoint_with_http_prefix() -> None:
+def test_AsyncConnector_init_alloydb_api_endpoint_with_http_prefix(
+    credentials: FakeCredentials,
+) -> None:
     """
     Test to check whether the __init__ method of AsyncConnector properly sets
     alloydb_api_endpoint when its URL has an 'http://' prefix.
     """
-    connector = AsyncConnector(alloydb_api_endpoint="http://alloydb.googleapis.com")
+    connector = AsyncConnector(
+        alloydb_api_endpoint="http://alloydb.googleapis.com", credentials=credentials
+    )
     assert connector._alloydb_api_endpoint == "alloydb.googleapis.com"
     connector.close()
 
 
-def test_AsyncConnector_init_alloydb_api_endpoint_with_https_prefix() -> None:
+def test_AsyncConnector_init_alloydb_api_endpoint_with_https_prefix(
+    credentials: FakeCredentials,
+) -> None:
     """
     Test to check whether the __init__ method of AsyncConnector properly sets
     alloydb_api_endpoint when its URL has an 'https://' prefix.
     """
-    connector = AsyncConnector(alloydb_api_endpoint="https://alloydb.googleapis.com")
+    connector = AsyncConnector(
+        alloydb_api_endpoint="https://alloydb.googleapis.com", credentials=credentials
+    )
     assert connector._alloydb_api_endpoint == "alloydb.googleapis.com"
     connector.close()
 

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -15,13 +15,13 @@
 import asyncio
 from typing import Union
 
-from aiohttp import ClientResponseError
 from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeConnectionInfo
 from mocks import FakeCredentials
 import pytest
 
+from google.api_core.exceptions import RetryError
 from google.cloud.alloydb.connector import AsyncConnector
 from google.cloud.alloydb.connector import IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
@@ -309,7 +309,7 @@ async def test_Connector_remove_cached_bad_instance(
     """
     instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
     async with AsyncConnector(credentials=credentials) as connector:
-        with pytest.raises(ClientResponseError):
+        with pytest.raises(RetryError):
             await connector.connect(instance_uri, "asyncpg")
         assert instance_uri not in connector._cache
 

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -27,7 +27,7 @@ from google.cloud.alloydb.connector import IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
 from google.cloud.alloydb.connector.instance import RefreshAheadCache
 
-ALLOYDB_API_ENDPOINT = "https://alloydb.googleapis.com"
+ALLOYDB_API_ENDPOINT = "alloydb.googleapis.com"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_async_connector.py
+++ b/tests/unit/test_async_connector.py
@@ -163,8 +163,6 @@ async def test_connect_and_close(credentials: FakeCredentials) -> None:
 
         # check connection is returned
         assert connection.result() is True
-        # outside of context manager check close cleaned up
-        assert connector._client.closed is True
 
 
 @pytest.mark.asyncio
@@ -244,8 +242,6 @@ async def test_context_manager_connect_and_close(
 
             # check connection is returned
             assert connection.result() is True
-        # outside of context manager check close cleaned up
-        assert fake_client.closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -21,70 +21,64 @@ from aioresponses import aioresponses
 from mocks import FakeCredentials
 import pytest
 
+from google.cloud import alloydb_v1beta
 from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector.utils import generate_keys
 from google.cloud.alloydb.connector.version import __version__ as version
 
 
-async def connectionInfo(request: Any) -> web.Response:
-    response = {
-        "ipAddress": "10.0.0.1",
-        "instanceUid": "123456789",
-    }
-    return web.Response(content_type="application/json", body=json.dumps(response))
+async def connectionInfo(request: Any) -> alloydb_v1beta.types.resources.ConnectionInfo:
+    ci = alloydb_v1beta.types.resources.ConnectionInfo()
+    ci.ip_address = "10.0.0.1"
+    ci.instance_uid = "123456789"
+    return ci
 
 
-async def connectionInfoPublicIP(request: Any) -> web.Response:
-    response = {
-        "ipAddress": "10.0.0.1",
-        "publicIpAddress": "127.0.0.1",
-        "instanceUid": "123456789",
-    }
-    return web.Response(content_type="application/json", body=json.dumps(response))
+async def connectionInfoPublicIP(request: Any) -> alloydb_v1beta.types.resources.ConnectionInfo:
+    ci = alloydb_v1beta.types.resources.ConnectionInfo()
+    ci.ip_address = "10.0.0.1"
+    ci.public_ip_address = "127.0.0.1"
+    ci.instance_uid = "123456789"
+    return ci
 
 
-async def connectionInfoPsc(request: Any) -> web.Response:
-    response = {
-        "ipAddress": None,
-        "publicIpAddress": None,
-        "pscDnsName": "x.y.alloydb.goog",
-        "instanceUid": "123456789",
-    }
-    return web.Response(content_type="application/json", body=json.dumps(response))
+async def connectionInfoPsc(request: Any) -> alloydb_v1beta.types.resources.ConnectionInfo:
+    ci = alloydb_v1beta.types.resources.ConnectionInfo()
+    ci.psc_dns_name = "x.y.alloydb.goog"
+    ci.instance_uid = "123456789"
+    return ci
 
 
-async def generateClientCertificate(request: Any) -> web.Response:
-    response = {
-        "caCert": "This is the CA cert",
-        "pemCertificateChain": [
-            "This is the client cert",
-            "This is the intermediate cert",
-            "This is the root cert",
-        ],
-    }
-    return web.Response(content_type="application/json", body=json.dumps(response))
+async def generateClientCertificate(request: Any) -> alloydb_v1beta.types.service.GenerateClientCertificateResponse:
+    ccr = alloydb_v1beta.types.service.GenerateClientCertificateResponse()
+    ccr.ca_cert = "This is the CA cert"
+    ccr.pem_certificate_chain.append("This is the client cert")
+    ccr.pem_certificate_chain.append("This is the intermediate cert")
+    ccr.pem_certificate_chain.append("This is the root cert")
+    return ccr
 
 
-@pytest.fixture
-async def client(aiohttp_client: Any) -> Any:
-    app = web.Application()
-    metadata_uri = "/v1beta/projects/test-project/locations/test-region/clusters/test-cluster/instances/test-instance/connectionInfo"
-    app.router.add_get(metadata_uri, connectionInfo)
-    metadata_public_ip_uri = "/v1beta/projects/test-project/locations/test-region/clusters/test-cluster/instances/public-instance/connectionInfo"
-    app.router.add_get(metadata_public_ip_uri, connectionInfoPublicIP)
-    metadata_psc_uri = "/v1beta/projects/test-project/locations/test-region/clusters/test-cluster/instances/psc-instance/connectionInfo"
-    app.router.add_get(metadata_psc_uri, connectionInfoPsc)
-    client_cert_uri = "/v1beta/projects/test-project/locations/test-region/clusters/test-cluster:generateClientCertificate"
-    app.router.add_post(client_cert_uri, generateClientCertificate)
-    return await aiohttp_client(app)
+class MockAlloyDBAdminAsyncClient:
+    async def get_connection_info(self, request: alloydb_v1beta.GetConnectionInfoRequest) -> alloydb_v1beta.types.resources.ConnectionInfo:
+        parent = request.parent
+        instance = parent.split("/")[-1]
+        if instance == "test-instance":
+            return connectionInfo(request)
+        elif instance == "public-instance":
+            return connectionInfoPublicIP(request)
+        else:
+            return connectionInfoPsc(request)
+        
+    async def generate_client_certificate(self, request: alloydb_v1beta.GenerateClientCertificateRequest) -> web.Response:
+        return generateClientCertificate(request)
 
 
 @pytest.mark.asyncio
-async def test__get_metadata(client: Any, credentials: FakeCredentials) -> None:
+async def test__get_metadata(credentials: FakeCredentials) -> None:
     """
     Test _get_metadata returns successfully.
     """
-    test_client = AlloyDBClient("", "", credentials, client)
+    test_client = AlloyDBClient("", "", credentials, MockAlloyDBAdminAsyncClient())
     ip_addrs = await test_client._get_metadata(
         "test-project",
         "test-region",
@@ -93,19 +87,19 @@ async def test__get_metadata(client: Any, credentials: FakeCredentials) -> None:
     )
     assert ip_addrs == {
         "PRIVATE": "10.0.0.1",
-        "PUBLIC": None,
-        "PSC": None,
+        "PUBLIC": "",
+        "PSC": "",
     }
 
 
 @pytest.mark.asyncio
 async def test__get_metadata_with_public_ip(
-    client: Any, credentials: FakeCredentials
+    credentials: FakeCredentials
 ) -> None:
     """
     Test _get_metadata returns successfully with Public IP.
     """
-    test_client = AlloyDBClient("", "", credentials, client)
+    test_client = AlloyDBClient("", "", credentials, MockAlloyDBAdminAsyncClient())
     ip_addrs = await test_client._get_metadata(
         "test-project",
         "test-region",
@@ -115,18 +109,18 @@ async def test__get_metadata_with_public_ip(
     assert ip_addrs == {
         "PRIVATE": "10.0.0.1",
         "PUBLIC": "127.0.0.1",
-        "PSC": None,
+        "PSC": "",
     }
 
 
 @pytest.mark.asyncio
 async def test__get_metadata_with_psc(
-    client: Any, credentials: FakeCredentials
+    credentials: FakeCredentials
 ) -> None:
     """
     Test _get_metadata returns successfully with PSC DNS name.
     """
-    test_client = AlloyDBClient("", "", credentials, client)
+    test_client = AlloyDBClient("", "", credentials, MockAlloyDBAdminAsyncClient())
     ip_addrs = await test_client._get_metadata(
         "test-project",
         "test-region",
@@ -134,8 +128,8 @@ async def test__get_metadata_with_psc(
         "psc-instance",
     )
     assert ip_addrs == {
-        "PRIVATE": None,
-        "PUBLIC": None,
+        "PRIVATE": "",
+        "PUBLIC": "",
         "PSC": "x.y.alloydb.goog",
     }
 
@@ -178,45 +172,14 @@ async def test__get_metadata_error(
     await client.close()
 
 
-async def test__get_metadata_error_parsing_json(
-    credentials: FakeCredentials,
-) -> None:
-    """
-    Test that aiohttp default error messages are raised when _get_metadata gets
-    a bad JSON response.
-    """
-    # mock AlloyDB API calls with exceptions
-    client = AlloyDBClient(
-        alloydb_api_endpoint="https://alloydb.googleapis.com",
-        quota_project=None,
-        credentials=credentials,
-    )
-    get_url = "https://alloydb.googleapis.com/v1beta/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance/connectionInfo"
-    resp_body = ["error"]  # invalid json
-    with aioresponses() as mocked:
-        mocked.get(
-            get_url,
-            status=403,
-            payload=resp_body,
-            repeat=True,
-        )
-        with pytest.raises(ClientResponseError) as exc_info:
-            await client._get_metadata(
-                "my-project", "my-region", "my-cluster", "my-instance"
-            )
-        assert exc_info.value.status == 403
-        assert exc_info.value.message == "Forbidden"
-    await client.close()
-
-
 @pytest.mark.asyncio
 async def test__get_client_certificate(
-    client: Any, credentials: FakeCredentials
+    credentials: FakeCredentials
 ) -> None:
     """
     Test _get_client_certificate returns successfully.
     """
-    test_client = AlloyDBClient("", "", credentials, client)
+    test_client = AlloyDBClient("", "", credentials, MockAlloyDBAdminAsyncClient())
     keys = await generate_keys()
     certs = await test_client._get_client_certificate(
         "test-project", "test-region", "test-cluster", keys[1]
@@ -260,37 +223,6 @@ async def test__get_client_certificate_error(
             )
         assert exc_info.value.status == 404
         assert exc_info.value.message == "The AlloyDB instance does not exist."
-    await client.close()
-
-
-async def test__get_client_certificate_error_parsing_json(
-    credentials: FakeCredentials,
-) -> None:
-    """
-    Test that aiohttp default error messages are raised when
-    _get_client_certificate gets a bad JSON response.
-    """
-    # mock AlloyDB API calls with exceptions
-    client = AlloyDBClient(
-        alloydb_api_endpoint="https://alloydb.googleapis.com",
-        quota_project=None,
-        credentials=credentials,
-    )
-    post_url = "https://alloydb.googleapis.com/v1beta/projects/my-project/locations/my-region/clusters/my-cluster:generateClientCertificate"
-    resp_body = ["error"]  # invalid json
-    with aioresponses() as mocked:
-        mocked.post(
-            post_url,
-            status=404,
-            payload=resp_body,
-            repeat=True,
-        )
-        with pytest.raises(ClientResponseError) as exc_info:
-            await client._get_client_certificate(
-                "my-project", "my-region", "my-cluster", ""
-            )
-        assert exc_info.value.status == 404
-        assert exc_info.value.message == "Not Found"
     await client.close()
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -98,7 +98,7 @@ async def test__get_metadata_error(
         quota_project=None,
         credentials=credentials,
     )
-    with pytest.raises(RetryError) as exc_info:
+    with pytest.raises(RetryError):
         await client._get_metadata(
             "my-project", "my-region", "my-cluster", "my-instance"
         )
@@ -135,11 +135,10 @@ async def test__get_client_certificate_error(
         quota_project=None,
         credentials=credentials,
     )
-    with pytest.raises(RetryError) as exc_info:
+    with pytest.raises(RetryError):
         await client._get_client_certificate(
             "my-project", "my-region", "my-cluster", ""
         )
-    print(exc_info)
     await client.close()
 
 
@@ -153,8 +152,7 @@ async def test_AlloyDBClient_init_(credentials: FakeCredentials) -> None:
     # verify base endpoint is set
     assert client._client.api_endpoint == "www.test-endpoint.com"
     # verify proper headers are set
-    got_user_agent = client._client.transport._wrapped_methods[client._client.transport.list_clusters]._metadata[0][1]
-    assert got_user_agent.startswith(f"alloydb-python-connector/{version}")
+    assert client._user_agent.startswith(f"alloydb-python-connector/{version}")
     assert client._client._client._client_options.quota_project_id == "my-quota-project"
     # close client
     await client.close()
@@ -173,8 +171,7 @@ async def test_AlloyDBClient_init_custom_user_agent(
         credentials,
         user_agent="custom-agent/v1.0.0 other-agent/v2.0.0",
     )
-    got_user_agent = client._client.transport._wrapped_methods[client._client.transport.list_clusters]._metadata[0][1]
-    assert got_user_agent.startswith(f"alloydb-python-connector/{version} custom-agent/v1.0.0 other-agent/v2.0.0")
+    assert client._user_agent.startswith(f"alloydb-python-connector/{version} custom-agent/v1.0.0 other-agent/v2.0.0")
     await client.close()
 
 
@@ -193,11 +190,10 @@ async def test_AlloyDBClient_user_agent(
     client = AlloyDBClient(
         "www.test-endpoint.com", "my-quota-project", credentials, driver=driver
     )
-    got_user_agent = client._client.transport._wrapped_methods[client._client.transport.list_clusters]._metadata[0][1]
     if driver is None:
-        assert got_user_agent.startswith(f"alloydb-python-connector/{version}")
+        assert client._user_agent.startswith(f"alloydb-python-connector/{version}")
     else:
-        assert got_user_agent.startswith(f"alloydb-python-connector/{version}+{driver}")
+        assert client._user_agent.startswith(f"alloydb-python-connector/{version}+{driver}")
     # close client
     await client.close()
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
-
-from aiohttp import ClientResponseError
-from aioresponses import aioresponses
-from mocks import FakeAlloyDBAdminAsyncClient, FakeCredentials
-import pytest
+from typing import Optional
 
 from google.api_core.exceptions import RetryError
-from google.cloud import alloydb_v1beta
+from mocks import FakeAlloyDBAdminAsyncClient
+from mocks import FakeCredentials
+import pytest
+
 from google.cloud.alloydb.connector.client import AlloyDBClient
 from google.cloud.alloydb.connector.utils import generate_keys
 from google.cloud.alloydb.connector.version import __version__ as version
@@ -46,9 +44,7 @@ async def test__get_metadata(credentials: FakeCredentials) -> None:
 
 
 @pytest.mark.asyncio
-async def test__get_metadata_with_public_ip(
-    credentials: FakeCredentials
-) -> None:
+async def test__get_metadata_with_public_ip(credentials: FakeCredentials) -> None:
     """
     Test _get_metadata returns successfully with Public IP.
     """
@@ -67,9 +63,7 @@ async def test__get_metadata_with_public_ip(
 
 
 @pytest.mark.asyncio
-async def test__get_metadata_with_psc(
-    credentials: FakeCredentials
-) -> None:
+async def test__get_metadata_with_psc(credentials: FakeCredentials) -> None:
     """
     Test _get_metadata returns successfully with PSC DNS name.
     """
@@ -106,9 +100,7 @@ async def test__get_metadata_error(
 
 
 @pytest.mark.asyncio
-async def test__get_client_certificate(
-    credentials: FakeCredentials
-) -> None:
+async def test__get_client_certificate(credentials: FakeCredentials) -> None:
     """
     Test _get_client_certificate returns successfully.
     """
@@ -171,7 +163,9 @@ async def test_AlloyDBClient_init_custom_user_agent(
         credentials,
         user_agent="custom-agent/v1.0.0 other-agent/v2.0.0",
     )
-    assert client._user_agent.startswith(f"alloydb-python-connector/{version} custom-agent/v1.0.0 other-agent/v2.0.0")
+    assert client._user_agent.startswith(
+        f"alloydb-python-connector/{version} custom-agent/v1.0.0 other-agent/v2.0.0"
+    )
     await client.close()
 
 
@@ -193,7 +187,9 @@ async def test_AlloyDBClient_user_agent(
     if driver is None:
         assert client._user_agent.startswith(f"alloydb-python-connector/{version}")
     else:
-        assert client._user_agent.startswith(f"alloydb-python-connector/{version}+{driver}")
+        assert client._user_agent.startswith(
+            f"alloydb-python-connector/{version}+{driver}"
+        )
     # close client
     await client.close()
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -81,23 +81,6 @@ async def test__get_metadata_with_psc(credentials: FakeCredentials) -> None:
     }
 
 
-async def test__get_metadata_error(
-    credentials: FakeCredentials,
-) -> None:
-    """
-    Test that AlloyDB API error messages are raised for _get_metadata.
-    """
-    client = AlloyDBClient(
-        alloydb_api_endpoint="alloydb.googleapis.com",
-        quota_project=None,
-        credentials=credentials,
-    )
-    with pytest.raises(RetryError):
-        await client._get_metadata(
-            "my-project", "my-region", "my-cluster", "my-instance"
-        )
-
-
 @pytest.mark.asyncio
 async def test__get_client_certificate(credentials: FakeCredentials) -> None:
     """
@@ -113,23 +96,6 @@ async def test__get_client_certificate(credentials: FakeCredentials) -> None:
     assert cert_chain[0] == "This is the client cert"
     assert cert_chain[1] == "This is the intermediate cert"
     assert cert_chain[2] == "This is the root cert"
-
-
-async def test__get_client_certificate_error(
-    credentials: FakeCredentials,
-) -> None:
-    """
-    Test that AlloyDB API error messages are raised for _get_client_certificate.
-    """
-    client = AlloyDBClient(
-        alloydb_api_endpoint="alloydb.googleapis.com",
-        quota_project=None,
-        credentials=credentials,
-    )
-    with pytest.raises(RetryError):
-        await client._get_client_certificate(
-            "my-project", "my-region", "my-cluster", ""
-        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -96,7 +96,6 @@ async def test__get_metadata_error(
         await client._get_metadata(
             "my-project", "my-region", "my-cluster", "my-instance"
         )
-    await client.close()
 
 
 @pytest.mark.asyncio
@@ -131,7 +130,6 @@ async def test__get_client_certificate_error(
         await client._get_client_certificate(
             "my-project", "my-region", "my-cluster", ""
         )
-    await client.close()
 
 
 @pytest.mark.asyncio
@@ -146,8 +144,6 @@ async def test_AlloyDBClient_init_(credentials: FakeCredentials) -> None:
     # verify proper headers are set
     assert client._user_agent.startswith(f"alloydb-python-connector/{version}")
     assert client._client._client._client_options.quota_project_id == "my-quota-project"
-    # close client
-    await client.close()
 
 
 @pytest.mark.asyncio
@@ -166,7 +162,6 @@ async def test_AlloyDBClient_init_custom_user_agent(
     assert client._user_agent.startswith(
         f"alloydb-python-connector/{version} custom-agent/v1.0.0 other-agent/v2.0.0"
     )
-    await client.close()
 
 
 @pytest.mark.parametrize(
@@ -190,8 +185,6 @@ async def test_AlloyDBClient_user_agent(
         assert client._user_agent.startswith(
             f"alloydb-python-connector/{version}+{driver}"
         )
-    # close client
-    await client.close()
 
 
 @pytest.mark.parametrize(
@@ -210,5 +203,3 @@ async def test_AlloyDBClient_use_metadata(
         "www.test-endpoint.com", "my-quota-project", credentials, driver=driver
     )
     assert client._use_metadata == expected
-    # close client
-    await client.close()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -14,7 +14,6 @@
 
 from typing import Optional
 
-from google.api_core.exceptions import RetryError
 from mocks import FakeAlloyDBAdminAsyncClient
 from mocks import FakeCredentials
 import pytest

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -16,13 +16,13 @@ import asyncio
 from threading import Thread
 from typing import Union
 
+from google.api_core.exceptions import RetryError
 from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeCredentials
 from mocks import write_static_info
 import pytest
 
-from google.api_core.exceptions import RetryError
 from google.cloud.alloydb.connector import Connector
 from google.cloud.alloydb.connector import IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -107,22 +107,30 @@ def test_Connector_init_ip_type(
     connector.close()
 
 
-def test_Connector_init_alloydb_api_endpoint_with_http_prefix() -> None:
+def test_Connector_init_alloydb_api_endpoint_with_http_prefix(
+    credentials: FakeCredentials,
+) -> None:
     """
     Test to check whether the __init__ method of Connector properly sets
     alloydb_api_endpoint when its URL has an 'http://' prefix.
     """
-    connector = Connector(alloydb_api_endpoint="http://alloydb.googleapis.com")
+    connector = Connector(
+        alloydb_api_endpoint="http://alloydb.googleapis.com", credentials=credentials
+    )
     assert connector._alloydb_api_endpoint == "alloydb.googleapis.com"
     connector.close()
 
 
-def test_Connector_init_alloydb_api_endpoint_with_https_prefix() -> None:
+def test_Connector_init_alloydb_api_endpoint_with_https_prefix(
+    credentials: FakeCredentials,
+) -> None:
     """
     Test to check whether the __init__ method of Connector properly sets
     alloydb_api_endpoint when its URL has an 'https://' prefix.
     """
-    connector = Connector(alloydb_api_endpoint="https://alloydb.googleapis.com")
+    connector = Connector(
+        alloydb_api_endpoint="https://alloydb.googleapis.com", credentials=credentials
+    )
     assert connector._alloydb_api_endpoint == "alloydb.googleapis.com"
     connector.close()
 

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -107,6 +107,26 @@ def test_Connector_init_ip_type(
     connector.close()
 
 
+def test_Connector_init_alloydb_api_endpoint_with_http_prefix() -> None:
+    """
+    Test to check whether the __init__ method of Connector properly sets
+    alloydb_api_endpoint when its URL has an 'http://' prefix.
+    """
+    connector = Connector(alloydb_api_endpoint="http://alloydb.googleapis.com")
+    assert connector._alloydb_api_endpoint == "alloydb.googleapis.com"
+    connector.close()
+
+
+def test_Connector_init_alloydb_api_endpoint_with_https_prefix() -> None:
+    """
+    Test to check whether the __init__ method of Connector properly sets
+    alloydb_api_endpoint when its URL has an 'https://' prefix.
+    """
+    connector = Connector(alloydb_api_endpoint="https://alloydb.googleapis.com")
+    assert connector._alloydb_api_endpoint == "alloydb.googleapis.com"
+    connector.close()
+
+
 def test_Connector_context_manager(credentials: FakeCredentials) -> None:
     """
     Test to check whether the __init__ method of Connector

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -16,7 +16,6 @@ import asyncio
 from threading import Thread
 from typing import Union
 
-from aiohttp import ClientResponseError
 from mock import patch
 from mocks import FakeAlloyDBClient
 from mocks import FakeCredentials
@@ -220,7 +219,7 @@ def test_Connector_remove_cached_bad_instance(
     """
     instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
     with Connector(credentials) as connector:
-        with pytest.raises(ClientResponseError):
+        with pytest.raises(Exception):
             connector.connect(instance_uri, "pg8000")
         assert instance_uri not in connector._cache
 

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -22,6 +22,7 @@ from mocks import FakeCredentials
 from mocks import write_static_info
 import pytest
 
+from google.api_core.exceptions import RetryError
 from google.cloud.alloydb.connector import Connector
 from google.cloud.alloydb.connector import IPTypes
 from google.cloud.alloydb.connector.exceptions import IPTypeNotFoundError
@@ -36,7 +37,7 @@ def test_Connector_init(credentials: FakeCredentials) -> None:
     """
     connector = Connector(credentials)
     assert connector._quota_project is None
-    assert connector._alloydb_api_endpoint == "https://alloydb.googleapis.com"
+    assert connector._alloydb_api_endpoint == "alloydb.googleapis.com"
     assert connector._client is None
     assert connector._credentials == credentials
     connector.close()
@@ -113,7 +114,7 @@ def test_Connector_context_manager(credentials: FakeCredentials) -> None:
     """
     with Connector(credentials) as connector:
         assert connector._quota_project is None
-        assert connector._alloydb_api_endpoint == "https://alloydb.googleapis.com"
+        assert connector._alloydb_api_endpoint == "alloydb.googleapis.com"
         assert connector._client is None
         assert connector._credentials == credentials
 
@@ -219,7 +220,7 @@ def test_Connector_remove_cached_bad_instance(
     """
     instance_uri = "projects/test-project/locations/test-region/clusters/test-cluster/instances/bad-test-instance"
     with Connector(credentials) as connector:
-        with pytest.raises(Exception):
+        with pytest.raises(RetryError):
             connector.connect(instance_uri, "pg8000")
         assert instance_uri not in connector._cache
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,27 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.cloud.alloydb.connector.utils import strip_http_prefix
+
+
+def test_strip_http_prefix_with_empty_url() -> None:
+    assert strip_http_prefix("") == ""
+
+
+def test_strip_http_prefix_with_url_having_http_prefix() -> None:
+    assert strip_http_prefix("http://google.com") == "google.com"
+
+
+def test_strip_http_prefix_with_url_having_https_prefix() -> None:
+    assert strip_http_prefix("https://google.com") == "google.com"


### PR DESCRIPTION
This PR replaces calls to the AlloyDB admin API that use `aiohttp.ClientSession` to use the `google.cloud.alloydb` package's `AlloyDBAdminAsyncClient` instead.

The dependencies for this change were added in https://github.com/GoogleCloudPlatform/alloydb-python-connector/pull/428.

Did a performance test of this change by creating a script to create 500 connections. I ran the script twice: when using the `AlloyDBAdminAsyncClient` and when using `aiohttp.ClientSession`. Got similar results:
```
Using AlloyDBAdminAsyncClient:
Elapsed time: 1483.8013787269592 seconds

Using aiohttp.ClientSession:
Elapsed time: 1478.003143787384 seconds
```
Because the performance is very similar, we can use the `AlloyDBAdminAsyncClient`.

In the error case, for example, when passing an invalid instance URI, it was verified that the `AlloyDBAdminAsyncClient` returns a proper error message:
```
google.api_core.exceptions.NotFound: 404 Resource 'projects/jovial-evening-444518-a1/locations/us-east4/clusters/my-cluster-invalid/instances/my-cluster-primary' was not found
```