### PR TITLE
chore: add dependencies for AlloyDBAdminAsyncClient library

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -126,7 +126,7 @@ def cover(session):
 def default(session, path):
     # Install all test dependencies, then install this package in-place.
     session.install("-r", "requirements-test.txt")
-    session.install("-e", ".")
+    session.install(".")
     session.install("-r", "requirements.txt")
     # Run pytest with coverage.
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -129,16 +129,26 @@ def default(session, path):
     session.install(".")
     session.install("-r", "requirements.txt")
     # Run pytest with coverage.
+    # Using the coverage command instead of `pytest --cov`, because
+    # `pytest ---cov` causes the module to be initialized twice, which returns
+    # this error: "ImportError: PyO3 modules compiled for CPython 3.8 or older
+    # may only be initialized once per interpreter process". More info about
+    # this is stated here: https://github.com/pytest-dev/pytest-cov/issues/614.
     session.run(
+        "coverage",
+        "run",
+        "--include=*/google/cloud/alloydb/connector/*.py",
+        "-m",
         "pytest",
-        "--cov=google.cloud.alloydb.connector",
         "-v",
-        "--cov-config=.coveragerc",
-        "--cov-report=",
-        "--cov-fail-under=0",
-        "--junitxml=sponge_log.xml",
         path,
         *session.posargs,
+    )
+    session.run(
+        "coverage",
+        "xml",
+        "-o",
+        "sponge_log.xml",
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ dependencies = [
     "requests",
     "google-auth",
     "protobuf",
+    "google-cloud-alloydb",
+    "google-api-core",
 ]
 
 package_root = os.path.abspath(os.path.dirname(__file__))

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -19,8 +19,8 @@ import sys
 
 
 def test_namespace_package_compat(tmp_path: pathlib.PosixPath) -> None:
-    # The ``google`` namespace package should not be masked
-    # by the presence of ``google-cloud-alloydb-connector``.
+    # The ``google`` namespace package should not be masked by the presence of
+    # `google-cloud-alloydb` and ``google-cloud-alloydb-connector``.
     google = tmp_path / "google"
     google.mkdir()
     google.joinpath("othermod.py").write_text("")
@@ -28,20 +28,11 @@ def test_namespace_package_compat(tmp_path: pathlib.PosixPath) -> None:
     cmd = [sys.executable, "-m", "google.othermod"]
     subprocess.check_call(cmd, env=env)
 
-    # The ``google.cloud`` namespace package should not be masked
-    # by the presence of ``google-cloud-alloydb-connector``.
+    # The ``google.cloud`` namespace package should not be masked by the presence of
+    # ``google-cloud-alloydb`` and ``google-cloud-alloydb-connector``.
     google_cloud = tmp_path / "google" / "cloud"
     google_cloud.mkdir()
     google_cloud.joinpath("othermod.py").write_text("")
     env = dict(os.environ, PYTHONPATH=str(tmp_path))
     cmd = [sys.executable, "-m", "google.cloud.othermod"]
-    subprocess.check_call(cmd, env=env)
-
-    # The ``google.cloud.sql`` namespace package should not be masked
-    # by the presence of ``google-cloud-alloydb-connector``.
-    google_cloud_alloydb = tmp_path / "google" / "cloud" / "alloydb"
-    google_cloud_alloydb.mkdir()
-    google_cloud_alloydb.joinpath("othermod.py").write_text("")
-    env = dict(os.environ, PYTHONPATH=str(tmp_path))
-    cmd = [sys.executable, "-m", "google.cloud.alloydb.othermod"]
     subprocess.check_call(cmd, env=env)


### PR DESCRIPTION
This change adds the `google.cloud.alloydb` and `google.api_core` packages as dependencies. These packages are required for the `AlloyDBAdminAsyncClient`, which is being added in https://github.com/GoogleCloudPlatform/alloydb-python-connector/pull/416.