### PR TITLE
fix: Modify AlloyDBClient to use sync transport for sync connector

### DIFF
--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -478,3 +478,36 @@ class FakeAlloyDBAdminAsyncClient:
         ccr.pem_certificate_chain.append("This is the intermediate cert")
         ccr.pem_certificate_chain.append("This is the root cert")
         return ccr
+
+
+class FakeAlloyDBAdminClient:
+    def get_connection_info(
+        self, request: alloydb_v1beta.GetConnectionInfoRequest
+    ) -> alloydb_v1beta.types.resources.ConnectionInfo:
+        ci = alloydb_v1beta.types.resources.ConnectionInfo()
+        ci.ip_address = "10.0.0.1"
+        ci.public_ip_address = "127.0.0.1"
+        ci.instance_uid = "123456789"
+        ci.psc_dns_name = "x.y.alloydb.goog"
+
+        parent = request.parent
+        instance = parent.split("/")[-1]
+        if instance == "test-instance":
+            ci.public_ip_address = ""
+            ci.psc_dns_name = ""
+        elif instance == "public-instance":
+            ci.psc_dns_name = ""
+        else:
+            ci.ip_address = ""
+            ci.public_ip_address = ""
+        return ci
+
+    def generate_client_certificate(
+        self, request: alloydb_v1beta.GenerateClientCertificateRequest
+    ) -> alloydb_v1beta.types.service.GenerateClientCertificateResponse:
+        ccr = alloydb_v1beta.types.service.GenerateClientCertificateResponse()
+        ccr.ca_cert = "This is the CA cert"
+        ccr.pem_certificate_chain.append("This is the client cert")
+        ccr.pem_certificate_chain.append("This is the intermediate cert")
+        ccr.pem_certificate_chain.append("This is the root cert")
+        return ccr


### PR DESCRIPTION
This is a fix for https://github.com/GoogleCloudPlatform/alloydb-python-connector/issues/435.

The sync connector will use the `AlloyDBAdminClient` with a `grpc` transport, and the async connector will use the `AlloyDBAdminAsyncClient` with a `grpc_asyncio` transport.