### PR TITLE
fix: support verify-full mode

### DIFF
--- a/google/cloud/alloydb/connector/connection_info.py
+++ b/google/cloud/alloydb/connector/connection_info.py
@@ -58,9 +58,6 @@ class ConnectionInfo:
 
         # create TLS context
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        # TODO: Set check_hostname to True to verify the identity in the
-        # certificate once PSC DNS is populated in all existing clusters.
-        context.check_hostname = False
         # force TLSv1.3
         context.minimum_version = ssl.TLSVersion.TLSv1_3
 


### PR DESCRIPTION
This PR allows the Python connector to support the most secure form of mTLS, which is `verify-full` mode:
https://www.postgresql.org/docs/current/libpq-ssl.html#LIBQ-SSL-CERTIFICATES. In `verify-full` mode, the hostname provided by the client is matched with the AuthProxy server's certificate's SAN field. If it does not match, the connection is rejected.

Previously, for PSC instances, the AuthProxy server certificates contained DNS names with trailing dots in the SAN field. But Python's OpenSSL library does not allow DNS names to contain trailing dots when doing the hostname verification. So we could not support `verify-full` mode.

As of now, all PSC instances that use the AlloyDB Python connector do not have DNS names with trailing dots in the SAN field anymore. So we can support `verify-full` mode now.