### PR TITLE
add asyncpg to hardcoded list of supported drivers

### DIFF
--- a/google/cloud/alloydbconnector/connector.py
+++ b/google/cloud/alloydbconnector/connector.py
@@ -27,6 +27,7 @@ from typing import Any, Optional, TYPE_CHECKING
 from google.auth import default
 from google.auth.credentials import TokenState
 from google.auth.credentials import with_scopes_if_required
+import google.cloud.alloydbconnector.asyncpg as asyncpg
 from google.auth.transport import requests
 
 import google.cloud.alloydb_connectors_v1.proto.resources_pb2 as connectorspb
@@ -204,6 +205,7 @@ class Connector:
             logger.debug(f"['{instance_uri}']: Connection info added to cache")
 
         connect_func = {
+            "asyncpg": asyncpg.connect,
             "pg8000": pg8000.connect,
         }
         # only accept supported database drivers


### PR DESCRIPTION
Potentially naive fix for #462

Unit tests passing, although I note some async related errors that indicate the tests may not be exercising things correctly...

```
========================================================= warnings summary =========================================================
tests/unit/test_async_connector.py::test_synchronous_init
  /home/dan/alloydb-python-connector/google/cloud/alloydbconnector/async_connector.py:104: RuntimeWarning: coroutine 'generate_keys' was never awaited
    self._keys = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/unit/test_instance.py::test_RefreshAheadCache_close
  /home/dan/alloydb-python-connector/.nox/unit-3-12/lib/python3.12/site-packages/cryptography/x509/name.py:233: RuntimeWarning: coroutine 'RefreshAheadCache._refresh_operation' was never awaited
    if not all(isinstance(x, NameAttribute) for x in attributes):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 100 passed, 2 warnings in 20.39s =================================================
nox > coverage xml -o sponge_log.xml
Wrote XML report to sponge_log.xml
nox > Session unit-3.12 was successful.
```