### PR TITLE
chore: prevent renovate-bot from updating psycopg2-binary to 2.9.10

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,5 +28,9 @@
       "matchLanguages": ["python"],
       "matchUpdateTypes": ["minor", "patch"],
     },
+    {
+      "matchPackageNames": ["psycopg2-binary"],
+      "allowedVersions": "!/2.9.10/"
+    },
   ],
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,8 +6,8 @@ pg8000==1.31.2
 # It is supported for macos-12 runner:
 # https://github.com/psycopg/psycopg2/issues/1737. But macos-12 runner is
 # deprecated: https://github.com/actions/runner-images/issues/10721. So we
-# install psycopg <2.9.10 on Python 3.9 for macos-latest runner.
-psycopg2-binary<2.9.10; python_version == "3.9" and sys_platform == "darwin"
+# install psycopg 2.9.9 on Python 3.9 for macos-latest runner.
+psycopg2-binary==2.9.9; python_version == "3.9" and sys_platform == "darwin"
 psycopg2-binary==2.9.10; python_version != "3.9" or sys_platform != "darwin"
 
 pytest==8.4.1


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/alloydb-python-connector/pull/465 didn't work. It created
https://github.com/GoogleCloudPlatform/alloydb-python-connector/pull/467, which wants to update the package to 2.9.10 for Python 3.9 on Darwin. Currently, Python 3.9 on Darwin is using 2.9.9.

So checking if updating the renovate.json file will help. Gemini mentioned this is the approach for this: [here](https://github.com/user-attachments/assets/b9b0cca9-13d1-4617-a759-97c7995305d2). By doing this, we can hopefully prevent renovate-bot from deciding to upgrade psycopg2-binary to version 2.9.10.

Note: For environments that are not using Python 3.9 on Darwin, `requirements-test.txt` is already using 2.9.10. So renovate-bot should only update to 2.9.11 when it becomes released.
