### PR TITLE
chore: delete aiohttp dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ classifiers = [
 ]
 dependencies = [
     "aiofiles",
-    "aiohttp",
     "cryptography>=42.0.0",
     "requests",
     "google-auth",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,6 +13,5 @@ psycopg2-binary==2.9.10; python_version != "3.9" or sys_platform != "darwin"
 pytest==8.4.1
 pytest-asyncio==1.0.0
 pytest-cov==6.2.1
-pytest-aiohttp==1.1.0
 SQLAlchemy[asyncio]==2.0.41
 aioresponses==0.7.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiofiles==24.1.0
-aiohttp==3.12.13
 cryptography==45.0.5
 google-auth==2.40.3
 requests==2.32.4

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -16,7 +16,6 @@ import asyncio
 from datetime import datetime
 from datetime import timedelta
 
-import aiohttp
 from mocks import FakeAlloyDBClient
 import pytest
 
@@ -71,18 +70,18 @@ async def test_RefreshAheadCache_init() -> None:
     can tell if the instance URI that's passed in is formatted correctly.
     """
     keys = asyncio.create_task(generate_keys())
-    async with aiohttp.ClientSession() as client:
-        cache = RefreshAheadCache(
-            "projects/test-project/locations/test-region/clusters/test-cluster/instances/test-instance",
-            client,
-            keys,
-        )
-        assert (
-            cache._project == "test-project"
-            and cache._region == "test-region"
-            and cache._cluster == "test-cluster"
-            and cache._name == "test-instance"
-        )
+    client = FakeAlloyDBClient()
+    cache = RefreshAheadCache(
+        "projects/test-project/locations/test-region/clusters/test-cluster/instances/test-instance",
+        client,
+        keys,
+    )
+    assert (
+        cache._project == "test-project"
+        and cache._region == "test-region"
+        and cache._cluster == "test-cluster"
+        and cache._name == "test-instance"
+    )
 
 
 @pytest.mark.asyncio
@@ -92,9 +91,9 @@ async def test_RefreshAheadCache_init_invalid_instant_uri() -> None:
     will throw error for invalid instance URI.
     """
     keys = asyncio.create_task(generate_keys())
-    async with aiohttp.ClientSession() as client:
-        with pytest.raises(ValueError):
-            RefreshAheadCache("invalid/instance/uri/", client, keys)
+    client = FakeAlloyDBClient()
+    with pytest.raises(ValueError):
+        RefreshAheadCache("invalid/instance/uri/", client, keys)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`aiohttp` is not being used anymore. So we can delete it. This PR also fixes `test_instance.py`, because `RefreshAheadCache` takes in a `FakeAlloyDBClient` object instead of an `aiohttp.ClientSession` object.