### PR TITLE
fix: modify get_preferred_ip to check for empty values

### DIFF
--- a/google/cloud/alloydbconnector/connection_info.py
+++ b/google/cloud/alloydbconnector/connection_info.py
@@ -79,7 +79,7 @@ class ConnectionInfo:
         supplied by ip_type. If no IP addressess with the given preference are found,
         an error is raised."""
         ip_address = self.ip_addrs.get(ip_type.value)
-        if ip_address is None:
+        if not ip_address:
             raise IPTypeNotFoundError(
                 "AlloyDB instance does not have an IP addresses matching "
                 f"type: '{ip_type.value}'"

--- a/tests/unit/test_connection_info.py
+++ b/tests/unit/test_connection_info.py
@@ -105,13 +105,27 @@ async def test_ConnectionInfo_get_preferred_ip(ip_type: IPTypes, expected: str) 
     assert ip_address == expected
 
 
-async def test_ConnectionInfo_get_preferred_ip_IPTypeNotFoundError() -> None:
+async def test_ConnectionInfo_get_preferred_ip_IPTypeNotFoundError_when_ip_type_not_exist() -> None:
     """Test that ConnectionInfo.get_preferred_ip throws IPTypeNotFoundError"""
     conn_info = ConnectionInfo(
         ["cert"],
         "cert",
         "key",
         {},
+        datetime.now(timezone.utc),
+    )
+    # check error is thrown
+    with pytest.raises(IPTypeNotFoundError):
+        conn_info.get_preferred_ip(ip_type=IPTypes.PUBLIC)
+
+
+async def test_ConnectionInfo_get_preferred_ip_IPTypeNotFoundError_when_empty_value() -> None:
+    """Test that ConnectionInfo.get_preferred_ip throws IPTypeNotFoundError"""
+    conn_info = ConnectionInfo(
+        ["cert"],
+        "cert",
+        "key",
+        {"PUBLIC": ""},
         datetime.now(timezone.utc),
     )
     # check error is thrown


### PR DESCRIPTION
getConnectionInfo RPC returns the IP type values as strings. The current approach only checks if the value is None, which is not a valid return type. This PR's change allows checking for None and empty string types.