### PR TITLE
chore: remove renovate-bot check to prevent psycopg2-binary update

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,9 +28,5 @@
       "matchLanguages": ["python"],
       "matchUpdateTypes": ["minor", "patch"],
     },
-    {
-      "matchPackageNames": ["psycopg2-binary"],
-      "allowedVersions": "!/2.9.10/"
-    },
   ],
 }


### PR DESCRIPTION
This PR removes the check that prevents renovate-bot from creating PRs that update the psycopg2-binary to 2.9.10. We won't need this check after #488 is merged, because it uses psycopg2-binary 2.9.11.

So this PR should only be submitted after #488 is submitted.