### PR TITLE
feat: drop support for Python 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.13"]
       fail-fast: false
     steps:
       - name: Checkout code
@@ -99,7 +99,7 @@ jobs:
       (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     strategy:
       matrix:
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.13"]
       fail-fast: false
     permissions:
       contents: read

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,8 +22,8 @@ BLACK_VERSION = "black==23.12.1"
 ISORT_VERSION = "isort==5.13.2"
 LINT_PATHS = ["google", "tests", "noxfile.py"]
 
-SYSTEM_TEST_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
-UNIT_TEST_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+SYSTEM_TEST_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
+UNIT_TEST_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ name = "google-cloud-alloydb-connector"
 authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 classifiers = [
     # Should be one of:
@@ -33,7 +33,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -73,7 +72,7 @@ version = { attr = "google.cloud.alloydbconnector.version.__version__" }
 include = ["google*"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 namespace_packages = true
 ignore_missing_imports = true
 warn_unused_configs = true

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,8 +2,8 @@ asyncpg==0.30.0
 mock==5.2.0
 pg8000==1.31.5
 psycopg2-binary==2.9.11
-pytest==8.4.2
-pytest-asyncio==1.2.0
+pytest==9.0.0
+pytest-asyncio==1.3.0
 pytest-cov==7.0.0
 SQLAlchemy[asyncio]==2.0.44
 aioresponses==0.7.8


### PR DESCRIPTION
Python 3.9 EOL was October 31, 2025: https://endoflife.date/python

After dropping Python 3.9, we can upgrade the following packages:
- `pytest-asyncio` to version 1.3.0: https://github.com/pytest-dev/pytest-asyncio/releases/tag/v1.3.0
- After upgrading `pytest-asyncio` to version 1.3.0, we can upgrade `pytest` to version 9.0.0, because `pytest-asyncio 1.2.0` doesn't support `pytest 9.0.0`: https://github.com/pytest-dev/pytest-asyncio/blob/0d3988f5adc16e8b364266c9ecda42a36d5892ff/pyproject.toml#L45 