### PR TITLE
fix: use modern PKCS#8 for key serialization

### DIFF
--- a/google/cloud/alloydbconnector/utils.py
+++ b/google/cloud/alloydbconnector/utils.py
@@ -35,7 +35,7 @@ async def _write_to_file(
 
     key_bytes = key.private_bytes(
         encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     )
 

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -459,7 +459,7 @@ def write_static_info(i: FakeInstance) -> io.StringIO:
     )
     priv_pem = priv_key.private_bytes(
         encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode("UTF-8")
     ca_cert, chain = i.generate_pem_certificate_chain(pub_pem)


### PR DESCRIPTION
This will allow us to eventually add support for post-quantum signature keys like ML-DSA. The PKCS#1 format (TraditionalOpenSSL) does not suport such keys and is a legacy format.